### PR TITLE
[HWORKS-635] Add pytest for hsml pojo classes

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -94,7 +94,7 @@ jobs:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: "python/setup.py"
-      - run: pip install -e 'python[dev]'
+      - run: pip install -e python[dev]
 
       - name: Display Python version
         run: python --version

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -3,7 +3,7 @@ name: python
 on: pull_request
 
 jobs:
-  stylecheck:
+  lint_stylecheck:
     name: Lint and Stylecheck
     runs-on: ubuntu-latest
 
@@ -26,7 +26,7 @@ jobs:
               - 'python/tests/**/*.py'
 
       - name: install deps
-        run: pip install ruff==0.4.1
+        run: pip install ruff==0.4.2
 
       - name: ruff on python files
         if: steps.get-changed-files.outputs.src_any_changed == 'true'
@@ -44,3 +44,120 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.get-changed-files.outputs.all_changed_files }}
         run: ruff format $ALL_CHANGED_FILES
+
+  unit_tests_ubuntu_utc:
+    name: Unit Testing (Ubuntu)
+    needs: lint_stylecheck
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Set Timezone
+        run: sudo timedatectl set-timezone UTC
+
+      - uses: actions/checkout@v4
+      - name: Copy README
+        run: cp README.md python/
+
+      - uses: actions/setup-python@v5
+        name: Setup Python
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "python/setup.py"
+      - run: pip install -e python[dev]
+
+      - name: Display Python version
+        run: python --version
+
+      - name: Run Pytest suite
+        run: pytest python/tests
+
+  unit_tests_ubuntu_local:
+    name: Unit Testing (Ubuntu) (Local TZ)
+    needs: lint_stylecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Timezone
+        run: sudo timedatectl set-timezone Europe/Amsterdam
+
+      - uses: actions/checkout@v4
+      - name: Copy README
+        run: cp README.md python/
+
+      - uses: actions/setup-python@v5
+        name: Setup Python
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "python/setup.py"
+      - run: pip install -e 'python[dev]'
+
+      - name: Display Python version
+        run: python --version
+
+      - name: Run Pytest suite
+        run: pytest python/tests
+
+  unit_tests_windows_utc:
+    name: Unit Testing (Windows)
+    needs: lint_stylecheck
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Set Timezone
+        run: tzutil /s "UTC"
+
+      - uses: actions/checkout@v4
+      - name: Copy README
+        run: cp README.md python/
+
+      - uses: actions/setup-python@v5
+        name: Setup Python
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "python/setup.py"
+      - run: pip install -e python[dev]
+
+      - name: Display Python version
+        run: python --version
+
+      - name: Run Pytest suite
+        run: pytest python/tests
+
+  unit_tests_windows_local:
+    name: Unit Testing (Windows) (Local TZ)
+    needs: lint_stylecheck
+    runs-on: windows-latest
+
+    steps:
+      - name: Set Timezone
+        run: tzutil /s "W. Europe Standard Time"
+
+      - uses: actions/checkout@v4
+      - name: Copy README
+        run: cp README.md python/
+
+      - uses: actions/setup-python@v5
+        name: Setup Python
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "python/setup.py"
+      - run: pip install -e python[dev]
+
+      - name: Display Python version
+        run: python --version
+
+      - name: Display pip freeze
+        run: pip freeze
+
+      - name: Run Pytest suite
+        run: pytest python/tests

--- a/python/hsml/client/__init__.py
+++ b/python/hsml/client/__init__.py
@@ -129,6 +129,12 @@ def get_serving_num_instances_limits():
     return _serving_num_instances_limits
 
 
+def is_scale_to_zero_required():
+    # scale-to-zero is required for KServe deployments if the Hopsworks variable `kube_serving_min_num_instances`
+    # is set to 0. Other possible values are -1 (unlimited num instances) or >1 num instances.
+    return get_serving_num_instances_limits()[0] == 0
+
+
 def get_knative_domain():
     global _knative_domain
     return _knative_domain

--- a/python/hsml/constants.py
+++ b/python/hsml/constants.py
@@ -38,11 +38,12 @@ class ARTIFACT_VERSION:
 
 
 class RESOURCES:
+    MIN_NUM_INSTANCES = 1  # disable scale-to-zero by default
     # default values, not hard limits
     MIN_CORES = 0.2
     MIN_MEMORY = 32
     MIN_GPUS = 0
-    MAX_CORES = 1
+    MAX_CORES = 2
     MAX_MEMORY = 1024
     MAX_GPUS = 0
 

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -379,11 +379,8 @@ class ServingApi:
             "logs",
         ]
         query_params = {"component": component, "tail": tail}
-        server_logs = _client._send_request(
-            "GET", path_params, query_params=query_params
-        )
         return deployable_component_logs.DeployableComponentLogs.from_response_json(
-            server_logs
+            _client._send_request("GET", path_params, query_params=query_params)
         )
 
     def _get_inference_request_host_header(

--- a/python/hsml/deployable_component.py
+++ b/python/hsml/deployable_component.py
@@ -14,16 +14,17 @@
 #   limitations under the License.
 
 import json
-from abc import abstractclassmethod, abstractmethod
+import humps
 from typing import Optional, Union
 
-import humps
+from abc import ABC, abstractmethod
+
 from hsml import util
 from hsml.inference_batcher import InferenceBatcher
 from hsml.resources import Resources
 
 
-class DeployableComponent:
+class DeployableComponent(ABC):
     """Configuration of a deployable component (predictor or transformer)."""
 
     def __init__(
@@ -40,7 +41,8 @@ class DeployableComponent:
             or InferenceBatcher()
         )
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def from_json(cls, json_decamelized):
         "To be implemented by the component type"
         pass

--- a/python/hsml/deployable_component.py
+++ b/python/hsml/deployable_component.py
@@ -14,11 +14,10 @@
 #   limitations under the License.
 
 import json
-import humps
+from abc import ABC, abstractmethod
 from typing import Optional, Union
 
-from abc import ABC, abstractmethod
-
+import humps
 from hsml import util
 from hsml.inference_batcher import InferenceBatcher
 from hsml.resources import Resources

--- a/python/hsml/deployable_component_logs.py
+++ b/python/hsml/deployable_component_logs.py
@@ -88,4 +88,4 @@ class DeployableComponentLogs:
         self._tail = tail
 
     def __repr__(self):
-        return f"DeployableComponentLogs(instance_name: {self._instance_name!r}, date: {self._created_at!r}, lines: {self._lines!r})"
+        return f"DeployableComponentLogs(instance_name: {self._instance_name!r}, date: {self._created_at!r}) \n{self._content!s}"

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -228,8 +228,7 @@ class Deployment:
         logs = self._serving_engine.get_logs(self, component, tail)
         if logs is not None:
             for log in logs:
-                print("Instance name: " + log.instance_name)
-                print(log.content, end="\n\n")
+                print(log, end="\n\n")
 
     def get_url(self):
         """Get url to the deployment in Hopsworks"""

--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -525,30 +525,30 @@ class ModelEngine:
         """Get all tags for a model."""
         return self._model_api.get_tags(model_instance)
 
-    def get_feature_view_provenance(self, model_obj):
+    def get_feature_view_provenance(self, model_instance):
         """Get the parent feature view of this model, based on explicit provenance.
         These feature views can be accessible, deleted or inaccessible.
         For deleted and inaccessible feature views, only a minimal information is
         returned.
 
         # Arguments
-            model_obj: Metadata object of model.
+            model_instance: Metadata object of model.
 
         # Returns
             `ProvenanceLinks`:  the feature view used to generate this model
         """
-        return self._model_api.get_feature_view_provenance(model_obj)
+        return self._model_api.get_feature_view_provenance(model_instance)
 
-    def get_training_dataset_provenance(self, model_obj):
+    def get_training_dataset_provenance(self, model_instance):
         """Get the parent training dataset of this model, based on explicit provenance.
         These training datasets can be accessible, deleted or inaccessible.
         For deleted and inaccessible feature views, only a minimal information is
         returned.
 
         # Arguments
-            model_obj: Metadata object of model.
+            model_instance: Metadata object of model.
 
         # Returns
             `ProvenanceLinks`:  the training dataset used to generate this model
         """
-        return self._model_api.get_training_dataset_provenance(model_obj)
+        return self._model_api.get_training_dataset_provenance(model_instance)

--- a/python/hsml/inference_batcher.py
+++ b/python/hsml/inference_batcher.py
@@ -57,7 +57,7 @@ class InferenceBatcher:
 
     @classmethod
     def from_json(cls, json_decamelized):
-        return InferenceBatcher(*cls.extract_fields_from_json(json_decamelized))
+        return InferenceBatcher(**cls.extract_fields_from_json(json_decamelized))
 
     @classmethod
     def extract_fields_from_json(cls, json_decamelized):
@@ -66,16 +66,21 @@ class InferenceBatcher:
             if "batching_configuration" in json_decamelized
             else json_decamelized
         )
-        enabled = util.extract_field_from_json(config, ["batching_enabled", "enabled"])
-        max_batch_size = util.extract_field_from_json(config, "max_batch_size")
-        max_latency = util.extract_field_from_json(config, "max_latency")
-        timeout = util.extract_field_from_json(config, "timeout")
+        kwargs = {}
+        kwargs["enabled"] = util.extract_field_from_json(
+            config, ["batching_enabled", "enabled"]
+        )
+        kwargs["max_batch_size"] = util.extract_field_from_json(
+            config, "max_batch_size"
+        )
+        kwargs["max_latency"] = util.extract_field_from_json(config, "max_latency")
+        kwargs["timeout"] = util.extract_field_from_json(config, "timeout")
 
-        return enabled, max_batch_size, max_latency, timeout
+        return kwargs
 
     def update_from_response_json(self, json_dict):
         json_decamelized = humps.decamelize(json_dict)
-        self.__init__(self.extract_fields_from_json(json_decamelized))
+        self.__init__(**self.extract_fields_from_json(json_decamelized))
         return self
 
     def json(self):

--- a/python/hsml/inference_endpoint.py
+++ b/python/hsml/inference_endpoint.py
@@ -41,13 +41,14 @@ class InferenceEndpointPort:
 
     @classmethod
     def from_json(cls, json_decamelized):
-        return InferenceEndpointPort(*cls.extract_fields_from_json(json_decamelized))
+        return InferenceEndpointPort(**cls.extract_fields_from_json(json_decamelized))
 
     @classmethod
     def extract_fields_from_json(cls, json_decamelized):
-        name = util.extract_field_from_json(json_decamelized, "name")
-        number = util.extract_field_from_json(json_decamelized, "number")
-        return name, number
+        kwargs = {}
+        kwargs["name"] = util.extract_field_from_json(json_decamelized, "name")
+        kwargs["number"] = util.extract_field_from_json(json_decamelized, "number")
+        return kwargs
 
     def to_dict(self):
         return {"name": self._name, "number": self._number}
@@ -93,9 +94,10 @@ class InferenceEndpoint:
 
     def get_port(self, name):
         """Get port by name"""
-        for port in self._ports:
-            if port.name == name:
-                return port
+        if self._ports is not None:
+            for port in self._ports:
+                if port.name == name:
+                    return port
         return None
 
     @classmethod
@@ -106,20 +108,27 @@ class InferenceEndpoint:
                 return []
             return [cls.from_json(endpoint) for endpoint in json_decamelized]
         else:
+            if "count" in json_decamelized:
+                if json_decamelized["count"] == 0:
+                    return []
+                return [
+                    cls.from_json(endpoint) for endpoint in json_decamelized["items"]
+                ]
             return cls.from_json(json_decamelized)
 
     @classmethod
     def from_json(cls, json_decamelized):
-        return InferenceEndpoint(*cls.extract_fields_from_json(json_decamelized))
+        return InferenceEndpoint(**cls.extract_fields_from_json(json_decamelized))
 
     @classmethod
     def extract_fields_from_json(cls, json_decamelized):
-        type = util.extract_field_from_json(json_decamelized, "type")
-        hosts = util.extract_field_from_json(json_decamelized, "hosts")
-        ports = util.extract_field_from_json(
-            json_decamelized, "ports", as_instance_of=InferenceEndpointPort
+        kwargs = {}
+        kwargs["type"] = util.extract_field_from_json(json_decamelized, "type")
+        kwargs["hosts"] = util.extract_field_from_json(json_decamelized, "hosts")
+        kwargs["ports"] = util.extract_field_from_json(
+            obj=json_decamelized, fields="ports", as_instance_of=InferenceEndpointPort
         )
-        return type, hosts, ports
+        return kwargs
 
     def to_dict(self):
         return {

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -17,21 +17,20 @@ import json
 from typing import Optional, Union
 
 import humps
-
 from hsml import client, deployment, util
 from hsml.constants import (
     ARTIFACT_VERSION,
-    PREDICTOR,
-    MODEL,
     INFERENCE_ENDPOINTS,
+    MODEL,
+    PREDICTOR,
     RESOURCES,
 )
-from hsml.transformer import Transformer
-from hsml.predictor_state import PredictorState
 from hsml.deployable_component import DeployableComponent
 from hsml.inference_batcher import InferenceBatcher
 from hsml.inference_logger import InferenceLogger
+from hsml.predictor_state import PredictorState
 from hsml.resources import PredictorResources
+from hsml.transformer import Transformer
 
 
 class Predictor(DeployableComponent):

--- a/python/hsml/predictor_state.py
+++ b/python/hsml/predictor_state.py
@@ -116,7 +116,7 @@ class PredictorState:
     @property
     def model_server_inference_path(self):
         """Inference path in the model server"""
-        return self.model_server_inference_path
+        return self._model_server_inference_path
 
     @property
     def internal_port(self):

--- a/python/hsml/predictor_state_condition.py
+++ b/python/hsml/predictor_state_condition.py
@@ -44,19 +44,19 @@ class PredictorStateCondition:
 
     @classmethod
     def from_json(cls, json_decamelized):
-        return PredictorStateCondition(*cls.extract_fields_from_json(json_decamelized))
+        return PredictorStateCondition(**cls.extract_fields_from_json(json_decamelized))
 
     @classmethod
     def extract_fields_from_json(cls, json_decamelized):
-        type = json_decamelized.pop("type")  # required
-        status = util.extract_field_from_json(json_decamelized, "status")
-        reason = util.extract_field_from_json(json_decamelized, "reason")
-
-        return type, status, reason
+        kwargs = {}
+        kwargs["type"] = json_decamelized.pop("type")  # required
+        kwargs["status"] = util.extract_field_from_json(json_decamelized, "status")
+        kwargs["reason"] = util.extract_field_from_json(json_decamelized, "reason")
+        return kwargs
 
     def update_from_response_json(self, json_dict):
         json_decamelized = humps.decamelize(json_dict)
-        self.__init__(*self.extract_fields_from_json(json_decamelized))
+        self.__init__(**self.extract_fields_from_json(json_decamelized))
         return self
 
     def json(self):

--- a/python/hsml/tag.py
+++ b/python/hsml/tag.py
@@ -48,13 +48,9 @@ class Tag:
     @classmethod
     def from_response_json(cls, json_dict):
         json_decamelized = humps.decamelize(json_dict)
-        if "count" in json_decamelized:
-            if json_decamelized["count"] == 0:
-                return []
-            else:
-                return [cls(**tag) for tag in json_decamelized["items"]]
-        else:
-            return [cls(**json_decamelized)]
+        if "count" not in json_decamelized or json_decamelized["count"] == 0:
+            return []
+        return [cls(**tag) for tag in json_decamelized["items"]]
 
     @property
     def name(self):
@@ -68,7 +64,7 @@ class Tag:
     @property
     def value(self):
         """Value of tag."""
-        return self.value
+        return self._value
 
     @value.setter
     def value(self, value):

--- a/python/hsml/transformer.py
+++ b/python/hsml/transformer.py
@@ -16,11 +16,10 @@
 from typing import Optional, Union
 
 import humps
-
 from hsml import client, util
 from hsml.constants import RESOURCES
-from hsml.resources import TransformerResources
 from hsml.deployable_component import DeployableComponent
+from hsml.resources import TransformerResources
 
 
 class Transformer(DeployableComponent):

--- a/python/hsml/transformer.py
+++ b/python/hsml/transformer.py
@@ -16,9 +16,11 @@
 from typing import Optional, Union
 
 import humps
+
 from hsml import client, util
-from hsml.deployable_component import DeployableComponent
+from hsml.constants import RESOURCES
 from hsml.resources import TransformerResources
+from hsml.deployable_component import DeployableComponent
 
 
 class Transformer(DeployableComponent):
@@ -36,6 +38,8 @@ class Transformer(DeployableComponent):
             )
             or self._get_default_resources()
         )
+        if resources.num_instances is None:
+            resources.num_instances = self._get_default_num_instances()
 
         super().__init__(script_file, resources)
 
@@ -47,19 +51,23 @@ class Transformer(DeployableComponent):
     def _validate_resources(cls, resources):
         if resources is not None:
             # ensure scale-to-zero for kserve deployments when required
-            if (
-                resources.num_instances != 0
-                and client.get_serving_num_instances_limits()[0] == 0
-            ):
+            if resources.num_instances != 0 and client.is_scale_to_zero_required():
                 raise ValueError(
                     "Scale-to-zero is required for KServe deployments in this cluster. Please, set the number of transformer instances to 0."
                 )
         return resources
 
     @classmethod
+    def _get_default_num_instances(cls):
+        return (
+            0  # enable scale-to-zero by default if required
+            if client.is_scale_to_zero_required()
+            else RESOURCES.MIN_NUM_INSTANCES
+        )
+
+    @classmethod
     def _get_default_resources(cls):
-        # enable scale-to-zero by default in kserve deployments
-        return TransformerResources(0)
+        return TransformerResources(cls._get_default_num_instances())
 
     @classmethod
     def from_json(cls, json_decamelized):

--- a/python/hsml/util.py
+++ b/python/hsml/util.py
@@ -124,6 +124,10 @@ def set_model_class(model):
         return SkLearnModel(**model)
     elif framework == MODEL.FRAMEWORK_PYTHON:
         return PyModel(**model)
+    else:
+        raise ValueError(
+            "framework {} is not a supported framework".format(str(framework))
+        )
 
 
 def input_example_to_json(input_example):
@@ -303,11 +307,12 @@ def extract_field_from_json(obj, fields, default=None, as_instance_of=None):
             if isinstance(value, list):
                 # if the field is a list, get all obj
                 value = [
-                    get_obj_from_json(subvalue, as_instance_of) for subvalue in value
+                    get_obj_from_json(obj=subvalue, cls=as_instance_of)
+                    for subvalue in value
                 ]
             else:
                 # otherwise, get single obj
-                value = get_obj_from_json(value, as_instance_of)
+                value = get_obj_from_json(obj=value, cls=as_instance_of)
     return value
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff"]
+dev = ["pytest==7.4.4", "pytest-mock==3.12.0", "ruff"]
 docs = [
     "mkdocs==1.5.3",
     "mkdocs-material==9.5.17",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2021 Logical Clocks AB
+#   Copyright 2024 Hopsworks AB
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -13,3 +13,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
+pytest_plugins = [
+    "tests.fixtures.backend_fixtures",
+    "tests.fixtures.model_fixtures",
+]

--- a/python/tests/fixtures/__init__.py
+++ b/python/tests/fixtures/__init__.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2021 Logical Clocks AB
+#   Copyright 2024 Hopsworks AB
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/python/tests/fixtures/backend_fixtures.py
+++ b/python/tests/fixtures/backend_fixtures.py
@@ -14,9 +14,11 @@
 #   limitations under the License.
 #
 
-import pytest
 import json
 import os
+
+import pytest
+
 
 FIXTURES_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/python/tests/fixtures/backend_fixtures.py
+++ b/python/tests/fixtures/backend_fixtures.py
@@ -1,0 +1,43 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import json
+import os
+
+FIXTURES_DIR = os.path.dirname(os.path.abspath(__file__))
+
+FIXTURES = [
+    "tag",
+    "model",
+    "resources",
+    "transformer",
+    "predictor",
+    "kafka_topic",
+    "inference_logger",
+    "inference_batcher",
+    "inference_endpoint",
+]
+
+backend_fixtures_json = {}
+for fixture in FIXTURES:
+    with open(os.path.join(FIXTURES_DIR, f"{fixture}_fixtures.json"), "r") as json_file:
+        backend_fixtures_json[fixture] = json.load(json_file)
+
+
+@pytest.fixture
+def backend_fixtures():
+    return backend_fixtures_json

--- a/python/tests/fixtures/inference_batcher_fixtures.json
+++ b/python/tests/fixtures/inference_batcher_fixtures.json
@@ -1,0 +1,54 @@
+{
+  "get_enabled": {
+    "response": {
+      "enabled": true
+    },
+    "response_nested": {
+      "batching_configuration": {
+        "enabled": true
+      }
+    }
+  },
+  "get_disabled": {
+    "response": {
+      "enabled": false
+    },
+    "response_nested": {
+      "batching_configuration": {
+        "enabled": true
+      }
+    }
+  },
+  "get_enabled_with_config": {
+    "response": {
+      "enabled": true,
+      "max_batch_size": 1,
+      "max_latency": 2,
+      "timeout": 3
+    },
+    "response_nested": {
+      "batching_configuration": {
+        "enabled": true,
+        "max_batch_size": 1,
+        "max_latency": 2,
+        "timeout": 3
+      }
+    }
+  },
+  "get_disabled_with_config": {
+    "response": {
+      "enabled": false,
+      "max_batch_size": 1,
+      "max_latency": 2,
+      "timeout": 3
+    },
+    "response_nested": {
+      "batching_configuration": {
+        "enabled": false,
+        "max_batch_size": 1,
+        "max_latency": 2,
+        "timeout": 3
+      }
+    }
+  }
+}

--- a/python/tests/fixtures/inference_endpoint_fixtures.json
+++ b/python/tests/fixtures/inference_endpoint_fixtures.json
@@ -1,0 +1,66 @@
+{
+  "get_port": {
+    "response": {
+      "name": "port_name",
+      "number": 12345
+    }
+  },
+  "get_empty": {
+    "response": {
+      "count": 0,
+      "items": []
+    }
+  },
+  "get_singleton": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "type": "LOAD_BALANCER",
+          "hosts": ["host1", "host2", "host3"],
+          "ports": [
+            {
+              "name": "port_name",
+              "number": 12345
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "get_list": {
+    "response": {
+      "count": 2,
+      "items": [
+        {
+          "type": "LOAD_BALANCER",
+          "hosts": ["host1", "host2"],
+          "ports": [
+            {
+              "name": "port_name",
+              "number": 12345
+            }
+          ]
+        },
+        {
+          "type": "NODE",
+          "hosts": 54321,
+          "ports": [
+            {
+              "name": "port_name",
+              "number": 12345
+            },
+            {
+              "name": "port_name_2",
+              "number": 54321
+            },
+            {
+              "name": "port_name_3",
+              "number": 15243
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/python/tests/fixtures/inference_logger_fixtures.json
+++ b/python/tests/fixtures/inference_logger_fixtures.json
@@ -1,0 +1,96 @@
+{
+  "get_mode_all": {
+    "response": {
+      "inference_logging": "ALL"
+    },
+    "init_args": {
+      "mode": "ALL"
+    }
+  },
+  "get_mode_inputs": {
+    "response": {
+      "inference_logging": "MODEL_INPUTS"
+    },
+    "init_args": {
+      "mode": "MODEL_INPUTS"
+    }
+  },
+  "get_mode_outputs": {
+    "response": {
+      "inference_logging": "MODEL_OUTPUTS"
+    },
+    "init_args": {
+      "mode": "MODEL_OUTPUTS"
+    }
+  },
+  "get_mode_none": {
+    "response": {
+      "inference_logging": "NONE"
+    },
+    "init_args": {
+      "mode": "NONE"
+    }
+  },
+  "get_mode_all_with_kafka_topic": {
+    "response": {
+      "inference_logging": "ALL",
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    },
+    "init_args": {
+      "mode": "ALL",
+      "kafka_topic": {
+        "name": "topic"
+      }
+    }
+  },
+  "get_mode_inputs_with_kafka_topic": {
+    "response": {
+      "inference_logging": "MODEL_INPUTS",
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    },
+    "init_args": {
+      "mode": "MODEL_INPUTS",
+      "kafka_topic": {
+        "name": "topic",
+        "num_replicas": 1,
+        "num_partitions": 2
+      }
+    }
+  },
+  "get_mode_outputs_with_kafka_topic": {
+    "response": {
+      "inference_logging": "MODEL_OUTPUTS",
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    },
+    "init_args": {
+      "mode": "MODEL_OUTPUTS",
+      "kafka_topic": {
+        "name": "topic",
+        "num_replicas": 1,
+        "num_partitions": 2
+      }
+    }
+  },
+  "get_mode_none_with_kafka_topic": {
+    "response": {
+      "inference_logging": "NONE",
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    },
+    "init_args": {
+      "mode": "NONE",
+      "kafka_topic": {
+        "name": "topic",
+        "num_replicas": 1,
+        "num_partitions": 2
+      }
+    }
+  }
+}

--- a/python/tests/fixtures/kafka_topic_fixtures.json
+++ b/python/tests/fixtures/kafka_topic_fixtures.json
@@ -1,0 +1,59 @@
+{
+  "get_existing_with_name_only": {
+    "response": {
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    }
+  },
+  "get_existing_with_name_and_config": {
+    "response": {
+      "kafka_topic_dto": {
+        "name": "topic",
+        "num_replicas": 1,
+        "num_partitions": 2
+      }
+    }
+  },
+  "get_existing_with_name_and_config_alternative": {
+    "response": {
+      "kafka_topic_dto": {
+        "name": "topic",
+        "num_of_replicas": 1,
+        "num_of_partitions": 2
+      }
+    }
+  },
+  "get_none": {
+    "response": {
+      "kafka_topic_dto": {
+        "name": "NONE"
+      }
+    }
+  },
+  "get_none_with_config": {
+    "response": {
+      "kafka_topic_dto": {
+        "name": "NONE",
+        "num_replicas": 1,
+        "num_partitions": 2
+      }
+    }
+  },
+  "get_create_with_name_only": {
+    "response": {
+      "kafka_topic_dto": {
+        "name": "CREATE"
+      }
+    }
+  },
+  "get_create_with_name_and_config": {
+    "response": {
+      "kafka_topic_dto": {
+        "name": "CREATE",
+        "num_replicas": 1,
+        "num_partitions": 2
+      }
+    }
+  }
+}

--- a/python/tests/fixtures/model_fixtures.json
+++ b/python/tests/fixtures/model_fixtures.json
@@ -1,0 +1,203 @@
+{
+  "get_base": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "id": "0",
+          "name": "basemodel",
+          "version": 0,
+          "created": "created",
+          "creator": "creator",
+          "environment": "environment.yml",
+          "description": "description",
+          "experiment_id": 1,
+          "project_name": "myproject",
+          "experiment_project_name": "myexperimentproject",
+          "metrics": { "acc": 0.7 },
+          "program": "program",
+          "user_full_name": "Full Name",
+          "model_schema": "model_schema.json",
+          "training_dataset": "training_dataset",
+          "input_example": "input_example.json",
+          "model_registry_id": 1,
+          "tags": [],
+          "href": "test_href"
+        }
+      ]
+    }
+  },
+  "get_python": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "id": "1",
+          "name": "pythonmodel",
+          "version": 0,
+          "created": "created",
+          "creator": "creator",
+          "environment": "environment.yml",
+          "description": "description",
+          "experiment_id": 1,
+          "project_name": "myproject",
+          "experiment_project_name": "myexperimentproject",
+          "metrics": { "acc": 0.7 },
+          "program": "program",
+          "user_full_name": "Full Name",
+          "model_schema": "model_schema.json",
+          "training_dataset": "training_dataset",
+          "input_example": "input_example.json",
+          "model_registry_id": 1,
+          "tags": [],
+          "framework": "PYTHON",
+          "href": "test_href"
+        }
+      ]
+    }
+  },
+  "get_sklearn": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "id": "2",
+          "name": "sklearnmodel",
+          "version": 0,
+          "created": "created",
+          "creator": "creator",
+          "environment": "environment.yml",
+          "description": "description",
+          "experiment_id": 1,
+          "project_name": "myproject",
+          "experiment_project_name": "myexperimentproject",
+          "metrics": { "acc": 0.7 },
+          "program": "program",
+          "user_full_name": "Full Name",
+          "model_schema": "model_schema.json",
+          "training_dataset": "training_dataset",
+          "input_example": "input_example.json",
+          "model_registry_id": 1,
+          "tags": [],
+          "framework": "SKLEARN",
+          "href": "test_href"
+        }
+      ]
+    }
+  },
+  "get_tensorflow": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "id": "3",
+          "name": "tensorflowmodel",
+          "version": 0,
+          "created": "created",
+          "creator": "creator",
+          "environment": "environment.yml",
+          "description": "description",
+          "experiment_id": 1,
+          "project_name": "myproject",
+          "experiment_project_name": "myexperimentproject",
+          "metrics": { "acc": 0.7 },
+          "program": "program",
+          "user_full_name": "Full Name",
+          "model_schema": "model_schema.json",
+          "training_dataset": "training_dataset",
+          "input_example": "input_example.json",
+          "model_registry_id": 1,
+          "tags": [],
+          "framework": "TENSORFLOW",
+          "href": "test_href"
+        }
+      ]
+    }
+  },
+  "get_torch": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "id": "4",
+          "name": "torchmodel",
+          "version": 0,
+          "created": "created",
+          "creator": "creator",
+          "environment": "environment.yml",
+          "description": "description",
+          "experiment_id": 1,
+          "project_name": "myproject",
+          "experiment_project_name": "myexperimentproject",
+          "metrics": { "acc": 0.7 },
+          "program": "program",
+          "user_full_name": "Full Name",
+          "model_schema": "model_schema.json",
+          "training_dataset": "training_dataset",
+          "input_example": "input_example.json",
+          "model_registry_id": 1,
+          "tags": [],
+          "framework": "TORCH",
+          "href": "test_href"
+        }
+      ]
+    }
+  },
+  "get_list": {
+    "response": {
+      "count": 2,
+      "items": [
+        {
+          "id": "1",
+          "name": "pythonmodel",
+          "version": 0,
+          "created": "created",
+          "creator": "creator",
+          "environment": "environment.yml",
+          "description": "description",
+          "experiment_id": 1,
+          "project_name": "myproject",
+          "experiment_project_name": "myexperimentproject",
+          "metrics": { "acc": 0.7 },
+          "program": "program",
+          "user_full_name": "Full Name",
+          "model_schema": "model_schema.json",
+          "training_dataset": "training_dataset",
+          "input_example": "input_example.json",
+          "model_registry_id": 1,
+          "tags": [],
+          "framework": "PYTHON",
+          "href": "test_href"
+        },
+        {
+          "id": "2",
+          "name": "pythonmodel",
+          "version": 0,
+          "created": "created",
+          "creator": "creator",
+          "environment": "environment.yml",
+          "description": "description",
+          "experiment_id": 2,
+          "project_name": "myproject",
+          "experiment_project_name": "myexperimentproject",
+          "metrics": { "acc": 0.7 },
+          "program": "program",
+          "user_full_name": "Full Name",
+          "model_schema": "model_schema.json",
+          "training_dataset": "training_dataset",
+          "input_example": "input_example.json",
+          "model_registry_id": 1,
+          "tags": [],
+          "framework": "PYTHON",
+          "href": "test_href"
+        }
+      ]
+    }
+  },
+  "get_empty": {
+    "response": {
+      "count": 0,
+      "items": []
+    }
+  }
+}

--- a/python/tests/fixtures/model_fixtures.py
+++ b/python/tests/fixtures/model_fixtures.py
@@ -1,0 +1,125 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import numpy as np
+import pandas as pd
+
+from hsml.model import Model as BaseModel
+from hsml.python.model import Model as PythonModel
+from hsml.sklearn.model import Model as SklearnModel
+from hsml.tensorflow.model import Model as TensorflowModel
+from hsml.torch.model import Model as TorchModel
+
+MODEL_BASE_ID = 0
+MODEL_PYTHON_ID = 1
+MODEL_SKLEARN_ID = 2
+MODEL_TENSORFLOW_ID = 3
+MODEL_TORCH_ID = 4
+
+MODEL_BASE_NAME = "basemodel"
+MODEL_PYTHON_NAME = "pythonmodel"
+MODEL_SKLEARN_NAME = "sklearnmodel"
+MODEL_TENSORFLOW_NAME = "tensorflowmodel"
+MODEL_TORCH_NAME = "torchmodel"
+
+# models
+
+
+@pytest.fixture
+def model_base():
+    return BaseModel(MODEL_BASE_ID, MODEL_BASE_NAME)
+
+
+@pytest.fixture
+def model_python():
+    return PythonModel(MODEL_PYTHON_ID, MODEL_PYTHON_NAME)
+
+
+@pytest.fixture
+def model_sklearn():
+    return SklearnModel(MODEL_SKLEARN_ID, MODEL_SKLEARN_NAME)
+
+
+@pytest.fixture
+def model_tensorflow():
+    return TensorflowModel(MODEL_TENSORFLOW_ID, MODEL_TENSORFLOW_NAME)
+
+
+@pytest.fixture
+def model_torch():
+    return TorchModel(MODEL_TORCH_ID, MODEL_TORCH_NAME)
+
+
+# input example
+
+
+@pytest.fixture
+def input_example_numpy():
+    return np.array([1, 2, 3, 4])
+
+
+@pytest.fixture
+def input_example_dict():
+    return {"instances": [[1, 2, 3, 4]]}
+
+
+@pytest.fixture
+def input_example_dataframe_pandas_dataframe():
+    return pd.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
+
+
+@pytest.fixture
+def input_example_dataframe_pandas_dataframe_empty():
+    return pd.DataFrame()
+
+
+@pytest.fixture
+def input_example_dataframe_pandas_series():
+    return pd.Series([1, 2, 3, 4])
+
+
+@pytest.fixture
+def input_example_dataframe_pandas_series_empty():
+    return pd.Series()
+
+
+@pytest.fixture
+def input_example_dataframe_list():
+    return [1, 2, 3, 4]
+
+
+# metrics
+
+
+@pytest.fixture
+def model_metrics():
+    return {"accuracy": 0.4, "rmse": 0.6}
+
+
+@pytest.fixture
+def model_metrics_wrong_type():
+    return [0.4, 0.6]
+
+
+@pytest.fixture
+def model_metrics_wrong_metric_type():
+    return {1: 0.4, 2: 0.6}
+
+
+@pytest.fixture
+def model_metrics_wrong_metric_value():
+    return {"accuracy": "non-number", "rmse": 0.4}

--- a/python/tests/fixtures/model_fixtures.py
+++ b/python/tests/fixtures/model_fixtures.py
@@ -14,15 +14,15 @@
 #   limitations under the License.
 #
 
-import pytest
 import numpy as np
 import pandas as pd
-
+import pytest
 from hsml.model import Model as BaseModel
 from hsml.python.model import Model as PythonModel
 from hsml.sklearn.model import Model as SklearnModel
 from hsml.tensorflow.model import Model as TensorflowModel
 from hsml.torch.model import Model as TorchModel
+
 
 MODEL_BASE_ID = 0
 MODEL_PYTHON_ID = 1

--- a/python/tests/fixtures/predictor_fixtures.json
+++ b/python/tests/fixtures/predictor_fixtures.json
@@ -1,0 +1,400 @@
+{
+  "get_deployments_singleton": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "id": 1,
+          "name": "test",
+          "description": "test_desc",
+          "created": "",
+          "creator": "",
+          "model_path": "test_model_path",
+          "model_name": "test_model_name",
+          "model_version": 1,
+          "model_framework": "PYTHON",
+          "model_server": "PYTHON",
+          "serving_tool": "KSERVE",
+          "api_protocol": "REST",
+          "artifact_version": 2,
+          "predictor": "predictor_file",
+          "transformer": "transformer_file",
+          "requested_instances": 1,
+          "requested_transformer_instances": 1,
+          "predictor_resources": {
+            "requested_instances": 1,
+            "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+            "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+          },
+          "transformer_resources": {
+            "requested_instances": 1,
+            "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+            "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+          },
+          "batching_configuration": {
+            "batching_enabled": true,
+            "max_batch_size": 1000,
+            "max_latency": 1000,
+            "timeout": 1000
+          },
+          "inference_logging": "ALL",
+          "kafka_topic_dto": {
+            "name": "topic"
+          }
+        }
+      ]
+    }
+  },
+  "get_deployments_empty": {
+    "response": {
+      "count": 0,
+      "items": []
+    }
+  },
+  "get_deployments_list": {
+    "response": {
+      "count": 2,
+      "items": [
+        {
+          "id": 1,
+          "name": "test",
+          "description": "test_desc",
+          "created": "",
+          "creator": "",
+          "model_path": "test_model_path",
+          "model_name": "test_model_name",
+          "model_version": 1,
+          "model_framework": "PYTHON",
+          "model_server": "PYTHON",
+          "serving_tool": "KSERVE",
+          "api_protocol": "REST",
+          "artifact_version": 2,
+          "predictor": "predictor_file",
+          "transformer": "transformer_file",
+          "requested_instances": 1,
+          "requested_transformer_instances": 1,
+          "predictor_resources": {
+            "requested_instances": 1,
+            "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+            "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+          },
+          "transformer_resources": {
+            "requested_instances": 1,
+            "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+            "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+          },
+          "batching_configuration": {
+            "batching_enabled": true,
+            "max_batch_size": 1000,
+            "max_latency": 1000,
+            "timeout": 1000
+          },
+          "inference_logging": "ALL",
+          "kafka_topic_dto": {
+            "name": "topic"
+          }
+        },
+        {
+          "id": 2,
+          "name": "test_2",
+          "description": "test_desc_2",
+          "created": "",
+          "creator": "",
+          "model_path": "test_model_path",
+          "model_name": "test_model_name",
+          "model_version": 2,
+          "model_framework": "PYTHON",
+          "model_server": "PYTHON",
+          "serving_tool": "KSERVE",
+          "api_protocol": "REST",
+          "artifact_version": 3,
+          "predictor": "predictor_file",
+          "transformer": "transformer_file",
+          "requested_instances": 1,
+          "requested_transformer_instances": 1,
+          "predictor_resources": {
+            "requested_instances": 1,
+            "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+            "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+          },
+          "transformer_resources": {
+            "requested_instances": 1,
+            "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+            "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+          },
+          "batching_configuration": {
+            "batching_enabled": true,
+            "max_batch_size": 1000,
+            "max_latency": 1000,
+            "timeout": 1000
+          },
+          "inference_logging": "ALL",
+          "kafka_topic_dto": {
+            "name": "topic"
+          }
+        }
+      ]
+    }
+  },
+  "get_deployment_tf_kserve_rest": {
+    "response": {
+      "id": 1,
+      "name": "test",
+      "description": "test_desc",
+      "created": "",
+      "creator": "",
+      "model_path": "test_model_path",
+      "model_name": "test_model_name",
+      "model_version": 1,
+      "model_framework": "TENSORFLOW",
+      "model_server": "TENSORFLOW_SERVING",
+      "serving_tool": "KSERVE",
+      "api_protocol": "REST",
+      "artifact_version": 2,
+      "requested_instances": 1,
+      "predictor_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "inference_logging": "ALL",
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    }
+  },
+  "get_deployment_tf_kserve_rest_trans": {
+    "response": {
+      "id": 1,
+      "name": "test",
+      "description": "test_desc",
+      "created": "",
+      "creator": "",
+      "model_path": "test_model_path",
+      "model_name": "test_model_name",
+      "model_version": 1,
+      "model_framework": "TENSORFLOW",
+      "model_server": "TENSORFLOW_SERVING",
+      "serving_tool": "KSERVE",
+      "api_protocol": "REST",
+      "artifact_version": 2,
+      "transformer": "transformer_file",
+      "requested_instances": 1,
+      "requested_transformer_instances": 1,
+      "predictor_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "transformer_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "batching_configuration": {
+        "batching_enabled": true,
+        "max_batch_size": 1000,
+        "max_latency": 1000,
+        "timeout": 1000
+      },
+      "inference_logging": "ALL",
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    }
+  },
+
+  "get_deployment_py_kserve_rest_pred": {
+    "response": {
+      "id": 1,
+      "name": "test",
+      "description": "test_desc",
+      "created": "",
+      "creator": "",
+      "model_path": "test_model_path",
+      "model_name": "test_model_name",
+      "model_version": 1,
+      "model_framework": "PYTHON",
+      "model_server": "PYTHON",
+      "serving_tool": "KSERVE",
+      "api_protocol": "REST",
+      "artifact_version": 2,
+      "predictor": "predictor_file",
+      "requested_instances": 1,
+      "predictor_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "batching_configuration": {
+        "batching_enabled": true,
+        "max_batch_size": 1000,
+        "max_latency": 1000,
+        "timeout": 1000
+      },
+      "inference_logging": "ALL",
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    }
+  },
+
+  "get_deployment_py_kserve_rest_pred_trans": {
+    "response": {
+      "id": 1,
+      "name": "test",
+      "description": "test_desc",
+      "created": "",
+      "creator": "",
+      "model_path": "test_model_path",
+      "model_name": "test_model_name",
+      "model_version": 1,
+      "model_framework": "PYTHON",
+      "model_server": "PYTHON",
+      "serving_tool": "KSERVE",
+      "api_protocol": "REST",
+      "artifact_version": 2,
+      "predictor": "predictor_file",
+      "transformer": "transformer_file",
+      "requested_instances": 1,
+      "requested_transformer_instances": 1,
+      "predictor_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "transformer_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "inference_logging": "ALL",
+      "batching_configuration": {
+        "batching_enabled": true,
+        "max_batch_size": 1000,
+        "max_latency": 1000,
+        "timeout": 1000
+      },
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    }
+  },
+
+  "get_deployment_py_kserve_grpc_pred": {
+    "response": {
+      "id": 1,
+      "name": "test",
+      "description": "test_desc",
+      "created": "",
+      "creator": "",
+      "model_path": "test_model_path",
+      "model_name": "test_model_name",
+      "model_version": 1,
+      "model_framework": "PYTHON",
+      "model_server": "PYTHON",
+      "serving_tool": "KSERVE",
+      "api_protocol": "GRPC",
+      "artifact_version": 2,
+      "predictor": "predictor_file",
+      "requested_instances": 1,
+      "predictor_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "inference_logging": "ALL",
+      "batching_configuration": {
+        "batching_enabled": true,
+        "max_batch_size": 1000,
+        "max_latency": 1000,
+        "timeout": 1000
+      },
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    }
+  },
+
+  "get_deployment_py_kserve_grpc_pred_trans": {
+    "response": {
+      "id": 1,
+      "name": "test",
+      "description": "test_desc",
+      "created": "",
+      "creator": "",
+      "model_path": "test_model_path",
+      "model_name": "test_model_name",
+      "model_version": 1,
+      "model_framework": "PYTHON",
+      "model_server": "PYTHON",
+      "serving_tool": "KSERVE",
+      "api_protocol": "GRPC",
+      "artifact_version": 2,
+      "predictor": "predictor_file",
+      "transformer": "transformer_file",
+      "requested_instances": 1,
+      "requested_transformer_instances": 1,
+      "predictor_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "transformer_resources": {
+        "requested_instances": 1,
+        "requests": { "cores": 0.2, "memory": 16, "gpus": 1 },
+        "limits": { "cores": 0.3, "memory": 17, "gpus": 2 }
+      },
+      "inference_logging": "ALL",
+      "batching_configuration": {
+        "batching_enabled": true,
+        "max_batch_size": 1000,
+        "max_latency": 1000,
+        "timeout": 1000
+      },
+      "kafka_topic_dto": {
+        "name": "topic"
+      }
+    }
+  },
+  "get_deployment_predictor_state": {
+    "response": {
+      "available_instances": 1,
+      "available_transformer_instances": 1,
+      "hopsworks_inference_path": "hopsworks/api/path",
+      "model_server_inference_path": "model-server/path",
+      "internal_port": 1234,
+      "revision": 1234,
+      "deployed": "1234",
+      "condition": {
+        "type": "TYPE",
+        "status": true,
+        "reason": "REASON"
+      },
+      "status": "RUNNING"
+    }
+  },
+  "get_deployment_component_logs_empty": {
+    "response": []
+  },
+  "get_deployment_component_logs_single": {
+    "response": [
+      {
+        "instance_name": "instance_name",
+        "content": "content"
+      }
+    ]
+  },
+  "get_deployment_component_logs_list": {
+    "response": [
+      {
+        "instance_name": "instance_name_2",
+        "content": "content_2"
+      },
+      {
+        "instance_name": "instance_name_2",
+        "content": "content_2"
+      }
+    ]
+  }
+}

--- a/python/tests/fixtures/resources_fixtures.json
+++ b/python/tests/fixtures/resources_fixtures.json
@@ -1,0 +1,155 @@
+{
+  "get_only_cores": {
+    "response": {
+      "cores": 0.2
+    }
+  },
+  "get_only_memory": {
+    "response": {
+      "memory": 16
+    }
+  },
+  "get_only_gpus": {
+    "response": {
+      "gpus": 1
+    }
+  },
+
+  "get_cores_and_memory": {
+    "response": {
+      "cores": 0.2,
+      "memory": 16
+    }
+  },
+
+  "get_cores_and_gpus": {
+    "response": {
+      "cores": 0.2,
+      "gpus": 1
+    }
+  },
+
+  "get_memory_and_gpus": {
+    "response": {
+      "memory": 16,
+      "gpus": 1
+    }
+  },
+
+  "get_cores_memory_and_gpus": {
+    "response": {
+      "cores": 0.2,
+      "memory": 16,
+      "gpus": 1
+    }
+  },
+  "get_component_resources_num_instances": {
+    "response": {
+      "num_instances": 1
+    }
+  },
+  "get_component_resources_requests": {
+    "response": {
+      "requests": {
+        "cores": 0.2,
+        "memory": 16,
+        "gpus": 1
+      }
+    }
+  },
+  "get_component_resources_limits": {
+    "response": {
+      "limits": {
+        "cores": 0.3,
+        "memory": 17,
+        "gpus": 2
+      }
+    }
+  },
+  "get_component_resources_num_instances_and_requests": {
+    "response": {
+      "num_instances": 1,
+      "requests": {
+        "cores": 0.2,
+        "memory": 16,
+        "gpus": 1
+      }
+    }
+  },
+  "get_component_resources_num_instances_and_limits": {
+    "response": {
+      "num_instances": 1,
+      "limits": {
+        "cores": 0.3,
+        "memory": 17,
+        "gpus": 2
+      }
+    }
+  },
+  "get_component_resources_num_instances_requests_and_limits": {
+    "response": {
+      "num_instances": 1,
+      "requests": {
+        "cores": 0.2,
+        "memory": 16,
+        "gpus": 1
+      },
+      "limits": {
+        "cores": 0.3,
+        "memory": 17,
+        "gpus": 2
+      }
+    }
+  },
+  "get_component_resources_requested_instances_and_predictor_resources": {
+    "response": {
+      "requested_instances": 1,
+      "predictor_resources": {
+        "requests": {
+          "cores": 0.2,
+          "memory": 16,
+          "gpus": 1
+        },
+        "limits": {
+          "cores": 0.3,
+          "memory": 17,
+          "gpus": 2
+        }
+      }
+    }
+  },
+  "get_component_resources_requested_instances_and_predictor_resources_alternative": {
+    "response": {
+      "num_instances": 1,
+      "resources": {
+        "requests": {
+          "cores": 0.2,
+          "memory": 16,
+          "gpus": 1
+        },
+        "limits": {
+          "cores": 0.3,
+          "memory": 17,
+          "gpus": 2
+        }
+      }
+    }
+  },
+  "get_component_resources_requested_instances_and_transformer_resources": {
+    "response": {
+      "requested_transformer_instances": 1,
+      "transformer_resources": {
+        "requests": {
+          "cores": 0.2,
+          "memory": 16,
+          "gpus": 1
+        },
+        "limits": {
+          "cores": 0.3,
+          "memory": 17,
+          "gpus": 2
+        }
+      }
+    }
+  }
+}

--- a/python/tests/fixtures/tag_fixtures.json
+++ b/python/tests/fixtures/tag_fixtures.json
@@ -1,0 +1,25 @@
+{
+  "get": {
+    "response": {
+      "count": 1,
+      "items": [
+        {
+          "name": "test_name",
+          "value": "test_value",
+          "schema": "test_schema",
+          "href": "test_href",
+          "expand": "test_expand",
+          "items": [],
+          "count": 0,
+          "type": "tagDTO"
+        }
+      ]
+    }
+  },
+  "get_empty": {
+    "response": {
+      "count": 0,
+      "items": []
+    }
+  }
+}

--- a/python/tests/fixtures/transformer_fixtures.json
+++ b/python/tests/fixtures/transformer_fixtures.json
@@ -1,0 +1,63 @@
+{
+  "get_deployment_with_transformer": {
+    "response": {
+      "name": "test",
+      "transformer": "transformer_file_name",
+      "transformer_resources": {
+        "requested_transformer_instances": 1,
+        "requests": {
+          "cores": 0.2,
+          "memory": 16,
+          "gpus": 1
+        },
+        "limits": {
+          "cores": 0.3,
+          "memory": 17,
+          "gpus": 2
+        }
+      }
+    }
+  },
+  "get_deployment_without_transformer": {
+    "response": {
+      "name": "test",
+      "predictor": "predictor_file_name",
+      "predictor_resources": {
+        "num_instances": 1,
+        "requests": {
+          "cores": 0.2,
+          "memory": 16,
+          "gpus": 1
+        },
+        "limits": {
+          "cores": 0.3,
+          "memory": 17,
+          "gpus": 2
+        }
+      }
+    }
+  },
+  "get_transformer_with_resources": {
+    "response": {
+      "script_file": "transformer_file_name",
+      "resources": {
+        "num_instances": 1,
+        "requests": {
+          "cores": 0.2,
+          "memory": 16,
+          "gpus": 1
+        },
+        "limits": {
+          "cores": 0.3,
+          "memory": 17,
+          "gpus": 2
+        }
+      }
+    }
+  },
+  "get_transformer_without_resources": {
+    "response": {
+      "script_file": "transformer_file_name"
+    }
+  }
+}

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -1,0 +1,174 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hsml.connection import (
+    Connection,
+    HOPSWORKS_PORT_DEFAULT,
+    HOSTNAME_VERIFICATION_DEFAULT,
+    CONNECTION_SAAS_HOSTNAME,
+)
+from hsml.core import model_api, model_registry_api, model_serving_api
+
+
+class TestConnection:
+
+    # constants
+
+    def test_constants(self):
+        # The purpose of this test is to ensure that (1) we don't make undesired changes to contant values
+        # that might break things somewhere else, and (2) we remember to update the pytests accordingly by
+        # adding / removing / updating tests, if necessary.
+        assert CONNECTION_SAAS_HOSTNAME == "c.app.hopsworks.ai"
+        assert HOPSWORKS_PORT_DEFAULT == 443
+        assert HOSTNAME_VERIFICATION_DEFAULT
+
+    # constructor
+
+    def test_constructor_default(self, mocker):
+        # Arrange
+        class MockConnection:
+            pass
+
+        mock_connection = MockConnection()
+        mock_connection.connect = mocker.MagicMock()
+        mock_connection.init = Connection.__init__
+        mock_model_api_init = mocker.patch(
+            "hsml.core.model_api.ModelApi.__init__", return_value=None
+        )
+        mock_model_registry_api = mocker.patch(
+            "hsml.core.model_registry_api.ModelRegistryApi.__init__", return_value=None
+        )
+        mock_model_serving_api = mocker.patch(
+            "hsml.core.model_serving_api.ModelServingApi.__init__", return_value=None
+        )
+
+        # Act
+        mock_connection.init(mock_connection)
+
+        # Assert
+        assert mock_connection._host is None
+        assert mock_connection._port == HOPSWORKS_PORT_DEFAULT
+        assert mock_connection._project is None
+        assert mock_connection._hostname_verification == HOSTNAME_VERIFICATION_DEFAULT
+        assert mock_connection._trust_store_path is None
+        assert mock_connection._api_key_file is None
+        assert mock_connection._api_key_value is None
+        assert isinstance(mock_connection._model_api, model_api.ModelApi)
+        assert isinstance(
+            mock_connection._model_registry_api, model_registry_api.ModelRegistryApi
+        )
+        assert isinstance(
+            mock_connection._model_serving_api, model_serving_api.ModelServingApi
+        )
+        assert not mock_connection._connected
+        mock_model_api_init.assert_called_once()
+        mock_model_registry_api.assert_called_once()
+        mock_model_serving_api.assert_called_once()
+        mock_connection.connect.assert_called_once()
+
+    def test_constructor(self, mocker):
+        # Arrange
+        class MockConnection:
+            pass
+
+        mock_connection = MockConnection()
+        mock_connection.connect = mocker.MagicMock()
+        mock_connection.init = Connection.__init__
+        mock_model_api_init = mocker.patch(
+            "hsml.core.model_api.ModelApi.__init__", return_value=None
+        )
+        mock_model_registry_api = mocker.patch(
+            "hsml.core.model_registry_api.ModelRegistryApi.__init__", return_value=None
+        )
+        mock_model_serving_api = mocker.patch(
+            "hsml.core.model_serving_api.ModelServingApi.__init__", return_value=None
+        )
+
+        # Act
+        mock_connection.init(
+            mock_connection,
+            host="host",
+            port=1234,
+            project="project",
+            hostname_verification=False,
+            trust_store_path="ts_path",
+            api_key_file="ak_file",
+            api_key_value="ak_value",
+        )
+
+        # Assert
+        assert mock_connection._host == "host"
+        assert mock_connection._port == 1234
+        assert mock_connection._project == "project"
+        assert not mock_connection._hostname_verification
+        assert mock_connection._trust_store_path == "ts_path"
+        assert mock_connection._api_key_file == "ak_file"
+        assert mock_connection._api_key_value == "ak_value"
+        assert isinstance(mock_connection._model_api, model_api.ModelApi)
+        assert isinstance(
+            mock_connection._model_registry_api, model_registry_api.ModelRegistryApi
+        )
+        assert isinstance(
+            mock_connection._model_serving_api, model_serving_api.ModelServingApi
+        )
+        assert not mock_connection._connected
+        mock_model_api_init.assert_called_once()
+        mock_model_registry_api.assert_called_once()
+        mock_model_serving_api.assert_called_once()
+        mock_connection.connect.assert_called_once()
+
+    # handlers
+
+    def test_get_model_registry(self, mocker):
+        # Arrange
+        mock_connection = mocker.MagicMock()
+        mock_connection.get_model_registry = Connection.get_model_registry
+        mock_connection._model_registry_api = mocker.MagicMock()
+        mock_connection._model_registry_api.get = mocker.MagicMock(return_value="mr")
+
+        # Act
+        mr = mock_connection.get_model_registry(mock_connection)
+
+        # Assert
+        assert mr == "mr"
+        mock_connection._model_registry_api.get.assert_called_once()
+
+    def test_get_model_serving(self, mocker):
+        # Arrange
+        mock_connection = mocker.MagicMock()
+        mock_connection.get_model_serving = Connection.get_model_serving
+        mock_connection._model_serving_api = mocker.MagicMock()
+        mock_connection._model_serving_api.get = mocker.MagicMock(return_value="ms")
+
+        # Act
+        ms = mock_connection.get_model_serving(mock_connection)
+
+        # Assert
+        assert ms == "ms"
+        mock_connection._model_serving_api.get.assert_called_once()
+
+    # connection
+
+    # TODO: Add tests for connection-related methods
+
+    def test_connect(self, mocker):
+        pass
+
+    def test_close(self, mocker):
+        pass
+
+    def test_connection(self, mocker):
+        pass

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -15,16 +15,15 @@
 #
 
 from hsml.connection import (
-    Connection,
+    CONNECTION_SAAS_HOSTNAME,
     HOPSWORKS_PORT_DEFAULT,
     HOSTNAME_VERIFICATION_DEFAULT,
-    CONNECTION_SAAS_HOSTNAME,
+    Connection,
 )
 from hsml.core import model_api, model_registry_api, model_serving_api
 
 
 class TestConnection:
-
     # constants
 
     def test_constants(self):

--- a/python/tests/test_constants.py
+++ b/python/tests/test_constants.py
@@ -1,0 +1,383 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import inspect
+from hsml import constants
+
+
+class TestConstants:
+
+    # NOTE
+    # This class contains validations for constants and enum values.
+    # The purpose of this class is to ensure that (1) we don't make undesired changes to contant values
+    # that might break things somewhere else, and (2) we remember to update the pytests accordingly by
+    # adding / removing / updating tests.
+
+    # This class includes the following validations:
+    # - Number of possible values of an Enum (to check for added/removed values)
+    # - Exact values of contants (to check for modified values)
+
+    # MODEL
+
+    def test_model_framework_constants(self):
+        # Arrange
+        model_frameworks = {
+            "FRAMEWORK_TENSORFLOW": "TENSORFLOW",
+            "FRAMEWORK_TORCH": "TORCH",
+            "FRAMEWORK_PYTHON": "PYTHON",
+            "FRAMEWORK_SKLEARN": "SKLEARN",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.MODEL,
+            num_values=len(model_frameworks),
+            expected_constants=model_frameworks,
+            prefix="FRAMEWORK",
+        )
+
+    # MODEL_REGISTRY
+
+    def test_model_registry_constants(self):
+        # Arrange
+        hopsfs_mount_prefix = {"HOPSFS_MOUNT_PREFIX": "/home/yarnapp/hopsfs/"}
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.MODEL_REGISTRY,
+            num_values=len(hopsfs_mount_prefix),
+            expected_constants=hopsfs_mount_prefix,
+        )
+
+    # MODEL_SERVING
+
+    def test_model_serving_constants(self):
+        # Arrange
+        models_dataset = {"MODELS_DATASET": "Models"}
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.MODEL_SERVING,
+            num_values=len(models_dataset),
+            expected_constants=models_dataset,
+        )
+
+    # ARTIFACT_VERSION
+
+    def test_artifact_version_constants(self):
+        # Arrange
+        artifact_versions = {"CREATE": "CREATE"}
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.ARTIFACT_VERSION,
+            num_values=len(artifact_versions),
+            expected_constants=artifact_versions,
+        )
+
+    # RESOURCES
+
+    def test_resources_min_constants(self):
+        # Arrange
+        min_resources = {
+            "MIN_NUM_INSTANCES": 1,
+            "MIN_CORES": 0.2,
+            "MIN_MEMORY": 32,
+            "MIN_GPUS": 0,
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.RESOURCES,
+            num_values=len(min_resources),
+            expected_constants=min_resources,
+            prefix="MIN",
+        )
+
+    def test_resources_max_constants(self):
+        # Arrange
+        max_resources = {
+            "MAX_CORES": 2,
+            "MAX_MEMORY": 1024,
+            "MAX_GPUS": 0,
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.RESOURCES,
+            num_values=len(max_resources),
+            expected_constants=max_resources,
+            prefix="MAX",
+        )
+
+    # KAFKA_TOPIC
+
+    def test_kafka_topic_names_constants(self):
+        # Arrange
+        kafka_topic_cons = {
+            "NONE": "NONE",
+            "CREATE": "CREATE",
+            "NUM_REPLICAS": 1,
+            "NUM_PARTITIONS": 1,
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.KAFKA_TOPIC,
+            num_values=len(kafka_topic_cons),
+            expected_constants=kafka_topic_cons,
+        )
+
+    # INFERENCE_LOGGER
+
+    def test_inference_logger_constants(self):
+        # Arrange
+        if_modes = {
+            "MODE_NONE": "NONE",
+            "MODE_ALL": "ALL",
+            "MODE_MODEL_INPUTS": "MODEL_INPUTS",
+            "MODE_PREDICTIONS": "PREDICTIONS",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.INFERENCE_LOGGER,
+            num_values=len(if_modes),
+            expected_constants=if_modes,
+            prefix="MODE",
+        )
+
+    # INFERENCE_BATCHER
+
+    def test_inference_batcher_constants(self):
+        # Arrange
+        if_batcher = {"ENABLED": False}
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.INFERENCE_BATCHER,
+            num_values=len(if_batcher),
+            expected_constants=if_batcher,
+        )
+
+    # DEPLOYMENT
+
+    def test_deployment_constants(self):
+        # Arrange
+        depl_actions = {"ACTION_START": "START", "ACTION_STOP": "STOP"}
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.DEPLOYMENT,
+            num_values=len(depl_actions),
+            expected_constants=depl_actions,
+            prefix="ACTION",
+        )
+
+    # PREDICTOR
+
+    def test_predictor_model_server_constants(self):
+        # Arrange
+        model_servers = {
+            "MODEL_SERVER_PYTHON": "PYTHON",
+            "MODEL_SERVER_TF_SERVING": "TENSORFLOW_SERVING",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.PREDICTOR,
+            num_values=len(model_servers),
+            expected_constants=model_servers,
+            prefix="MODEL_SERVER",
+        )
+
+    def test_predictor_serving_tool_constants(self):
+        # Arrange
+        serving_tools = {
+            "SERVING_TOOL_DEFAULT": "DEFAULT",
+            "SERVING_TOOL_KSERVE": "KSERVE",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.PREDICTOR,
+            num_values=len(serving_tools),
+            expected_constants=serving_tools,
+            prefix="SERVING_TOOL",
+        )
+
+    # PREDICTOR_STATE
+
+    def test_predictor_state_status_constants(self):
+        # Arrange
+        predictor_states = {
+            "STATUS_CREATING": "Creating",
+            "STATUS_CREATED": "Created",
+            "STATUS_STARTING": "Starting",
+            "STATUS_FAILED": "Failed",
+            "STATUS_RUNNING": "Running",
+            "STATUS_IDLE": "Idle",
+            "STATUS_UPDATING": "Updating",
+            "STATUS_STOPPING": "Stopping",
+            "STATUS_STOPPED": "Stopped",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.PREDICTOR_STATE,
+            num_values=len(predictor_states),
+            expected_constants=predictor_states,
+            prefix="STATUS",
+        )
+
+    def test_predictor_state_condition_constants(self):
+        # Arrange
+        predictor_states = {
+            "CONDITION_TYPE_STOPPED": "STOPPED",
+            "CONDITION_TYPE_SCHEDULED": "SCHEDULED",
+            "CONDITION_TYPE_INITIALIZED": "INITIALIZED",
+            "CONDITION_TYPE_STARTED": "STARTED",
+            "CONDITION_TYPE_READY": "READY",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.PREDICTOR_STATE,
+            num_values=len(predictor_states),
+            expected_constants=predictor_states,
+            prefix="CONDITION",
+        )
+
+    # INFERENCE_ENDPOINTS
+
+    def test_inference_endpoints_type_constants(self):
+        # Arrange
+        ie_types = {
+            "ENDPOINT_TYPE_NODE": "NODE",
+            "ENDPOINT_TYPE_KUBE_CLUSTER": "KUBE_CLUSTER",
+            "ENDPOINT_TYPE_LOAD_BALANCER": "LOAD_BALANCER",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.INFERENCE_ENDPOINTS,
+            num_values=len(ie_types),
+            expected_constants=ie_types,
+            prefix="ENDPOINT_TYPE",
+        )
+
+    def test_inference_endpoints_port_constants(self):
+        # Arrange
+        ie_ports = {
+            "PORT_NAME_HTTP": "HTTP",
+            "PORT_NAME_HTTPS": "HTTPS",
+            "PORT_NAME_STATUS_PORT": "STATUS",
+            "PORT_NAME_TLS": "TLS",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.INFERENCE_ENDPOINTS,
+            num_values=len(ie_ports),
+            expected_constants=ie_ports,
+            prefix="PORT_NAME",
+        )
+
+    def test_inference_endpoints_api_protocol_constants(self):
+        # Arrange
+        ie_api_protocols = {
+            "API_PROTOCOL_REST": "REST",
+            "API_PROTOCOL_GRPC": "GRPC",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.INFERENCE_ENDPOINTS,
+            num_values=len(ie_api_protocols),
+            expected_constants=ie_api_protocols,
+            prefix="API_PROTOCOL",
+        )
+
+    # DEPLOYABLE_COMPONENT
+
+    def test_inference_endpoints_deployable_component_constants(self):
+        # Arrange
+        depl_components = {
+            "PREDICTOR": "predictor",
+            "TRANSFORMER": "transformer",
+        }
+
+        # Assert
+        self._check_added_modified_or_removed_values(
+            constants.DEPLOYABLE_COMPONENT,
+            num_values=len(depl_components),
+            expected_constants=depl_components,
+        )
+
+    # Auxiliary methods
+
+    def _check_added_modified_or_removed_values(
+        self, cls, num_values, expected_constants=None, prefix=None
+    ):
+        cname = cls.__name__ + ("." + prefix if prefix is not None else "")
+        const_dict = self._get_contants_name_value_dict(cls, prefix=prefix)
+        # exact constants
+        if expected_constants is not None:
+            # constant names
+            added_cnames = const_dict.keys() - expected_constants.keys()
+            removed_cnames = expected_constants.keys() - const_dict.keys()
+
+            assert len(added_cnames) == 0, (
+                f"One or more constants were added under {cname} with names {added_cnames}. "
+                + "If it was intentional, please add/remove/update tests accordingly (not only in this file, "
+                + "but wherever it corresponds)."
+            )
+
+            assert len(removed_cnames) == 0, (
+                f"One or more constants were removed under {cname} with names {removed_cnames}. "
+                + "If it was intentional, please add/remove/update tests accordingly (not only in this file, "
+                + "but wherever it corresponds)."
+            )
+
+            assert const_dict.keys() == expected_constants.keys(), (
+                f"One or more constants under {cname} were modified from {removed_cnames} to {added_cnames}. "
+                + "If it was intentional, please add/remove/update tests accordingly (not only in this file, "
+                + "but wherever it corresponds)."
+            )
+
+            # constant values
+            for cname, cvalue in expected_constants.items():
+                full_cname = f"{cls.__name__}.{cname}"
+                assert cvalue == const_dict[cname], (
+                    f"The constant {full_cname} was modified from {cvalue} to {const_dict[cname]}. "
+                    + "If it was intentional, please add/remove/update tests accordingly (not only in this file, "
+                    + "but wherever it corresponds)."
+                )
+        else:
+            # number of values
+            assert len(const_dict) == num_values, (
+                f"A constant was added/removed under {cname}. If it was intentional, please "
+                + "add/remove/update tests accordingly (not only in this file, but wherever it corresponds)."
+            )
+
+    def _get_contants_name_value_dict(self, cls, prefix=None) -> dict:
+        const_dict = dict()
+        for m in inspect.getmembers(cls, lambda m: not (inspect.isroutine(m))):
+            n = m[0]  # name
+            if (prefix is not None and n.startswith(prefix)) or (
+                prefix is None and not (n.startswith("__") and n.endswith("__"))
+            ):
+                const_dict[n] = m[1]  # value
+        return const_dict

--- a/python/tests/test_constants.py
+++ b/python/tests/test_constants.py
@@ -14,11 +14,11 @@
 #   limitations under the License.
 
 import inspect
+
 from hsml import constants
 
 
 class TestConstants:
-
     # NOTE
     # This class contains validations for constants and enum values.
     # The purpose of this class is to ensure that (1) we don't make undesired changes to contant values

--- a/python/tests/test_decorators.py
+++ b/python/tests/test_decorators.py
@@ -14,17 +14,15 @@
 #   limitations under the License.
 
 import pytest
-
 from hsml.decorators import (
-    connected,
-    not_connected,
     HopsworksConnectionError,
     NoHopsworksConnectionError,
+    connected,
+    not_connected,
 )
 
 
 class TestDecorators:
-
     # test not connected
 
     def test_not_connected_valid(self, mocker):

--- a/python/tests/test_decorators.py
+++ b/python/tests/test_decorators.py
@@ -1,0 +1,84 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytest
+
+from hsml.decorators import (
+    connected,
+    not_connected,
+    HopsworksConnectionError,
+    NoHopsworksConnectionError,
+)
+
+
+class TestDecorators:
+
+    # test not connected
+
+    def test_not_connected_valid(self, mocker):
+        # Arrange
+        mock_instance = mocker.MagicMock()
+        mock_instance._connected = False
+
+        @not_connected
+        def assert_not_connected(inst, arg, key_arg):
+            assert not inst._connected
+            assert arg == "arg"
+            assert key_arg == "key_arg"
+
+        # Act
+        assert_not_connected(mock_instance, "arg", key_arg="key_arg")
+
+    def test_not_connected_invalid(self, mocker):
+        # Arrange
+        mock_instance = mocker.MagicMock()
+        mock_instance._connected = True
+
+        @not_connected
+        def assert_not_connected(inst, arg, key_arg):
+            pass
+
+        # Act
+        with pytest.raises(HopsworksConnectionError):
+            assert_not_connected(mock_instance, "arg", key_arg="key_arg")
+
+    # test connected
+
+    def test_connected_valid(self, mocker):
+        # Arrange
+        mock_instance = mocker.MagicMock()
+        mock_instance._connected = True
+
+        @connected
+        def assert_connected(inst, arg, key_arg):
+            assert inst._connected
+            assert arg == "arg"
+            assert key_arg == "key_arg"
+
+        # Act
+        assert_connected(mock_instance, "arg", key_arg="key_arg")
+
+    def test_connected_invalid(self, mocker):
+        # Arrange
+        mock_instance = mocker.MagicMock()
+        mock_instance._connected = False
+
+        @connected
+        def assert_connected(inst, arg, key_arg):
+            pass
+
+        # Act
+        with pytest.raises(NoHopsworksConnectionError):
+            assert_connected(mock_instance, "arg", key_arg="key_arg")

--- a/python/tests/test_deployable_component.py
+++ b/python/tests/test_deployable_component.py
@@ -14,12 +14,10 @@
 #   limitations under the License.
 #
 
-from hsml import deployable_component
-from hsml import inference_batcher
+from hsml import deployable_component, inference_batcher
 
 
 class TestDeployableComponent:
-
     # from response json
 
     def test_from_response_json(self, mocker):

--- a/python/tests/test_deployable_component.py
+++ b/python/tests/test_deployable_component.py
@@ -1,0 +1,108 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hsml import deployable_component
+from hsml import inference_batcher
+
+
+class TestDeployableComponent:
+
+    # from response json
+
+    def test_from_response_json(self, mocker):
+        # Arrange
+        json = {"test": "test"}
+        mock_from_json = mocker.patch(
+            "hsml.deployable_component.DeployableComponent.from_json",
+            return_value="from_json_result",
+        )
+
+        # Act
+        result = deployable_component.DeployableComponent.from_response_json(json)
+
+        # Assert
+        assert result == "from_json_result"
+        mock_from_json.assert_called_once_with(json)
+
+    # constructor
+
+    def test_constructor_default(self, mocker):
+        # Arrange
+        mock_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=None
+        )
+        mock_ib_init = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.__init__", return_value=None
+        )
+
+        class DeployableComponentChild(deployable_component.DeployableComponent):
+            def from_json():
+                pass
+
+            def update_from_response_json():
+                pass
+
+            def to_dict():
+                pass
+
+        # Act
+        dc = DeployableComponentChild()
+
+        # Assert
+        assert dc.script_file is None
+        assert dc.resources is None
+        mock_get_obj_from_json.assert_called_once_with(
+            None, inference_batcher.InferenceBatcher
+        )
+        mock_ib_init.assert_called_once()
+
+    def test_constructor_with_params(self, mocker):
+        # Arrange
+        script_file = "script_file"
+        resources = {}
+        inf_batcher = inference_batcher.InferenceBatcher()
+        mock_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=inf_batcher
+        )
+        mock_ib_init = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.__init__", return_value=None
+        )
+
+        class DeployableComponentChild(deployable_component.DeployableComponent):
+            def from_json():
+                pass
+
+            def update_from_response_json():
+                pass
+
+            def to_dict():
+                pass
+
+        # Act
+        dc = DeployableComponentChild(
+            script_file=script_file,
+            resources=resources,
+            inference_batcher=inf_batcher,
+        )
+
+        # Assert
+        assert dc.script_file == script_file
+        assert dc.resources == resources
+        mock_get_obj_from_json.assert_called_once_with(
+            inf_batcher, inference_batcher.InferenceBatcher
+        )
+        assert dc.inference_batcher == inf_batcher
+        mock_ib_init.assert_not_called()

--- a/python/tests/test_deployable_component_logs.py
+++ b/python/tests/test_deployable_component_logs.py
@@ -14,14 +14,13 @@
 #   limitations under the License.
 #
 
-import humps
-
-from hsml import deployable_component_logs
 import datetime
+
+import humps
+from hsml import deployable_component_logs
 
 
 class TestDeployableComponentLogs:
-
     # from response json
 
     def test_from_response_json(self, mocker, backend_fixtures):
@@ -89,14 +88,14 @@ class TestDeployableComponentLogs:
 
     # constructor
 
-    def test_constructor(self, mocker, backend_fixtures):
+    def test_constructor(self, backend_fixtures):
         # Arrange
         json = backend_fixtures["predictor"]["get_deployment_component_logs_single"][
             "response"
         ]
         instance_name = json[0]["instance_name"]
         content = json[0]["content"]
-        mock_now = datetime.datetime.now()
+        now = datetime.datetime.now()
 
         # Act
         dcl = deployable_component_logs.DeployableComponentLogs(
@@ -106,7 +105,6 @@ class TestDeployableComponentLogs:
         # Assert
         assert dcl.instance_name == instance_name
         assert dcl.content == content
-        assert (
-            dcl.created_at > mock_now
-            and dcl.created_at < mock_now + datetime.timedelta(seconds=1)
+        assert (dcl.created_at >= now) and (
+            dcl.created_at < (now + datetime.timedelta(seconds=1))
         )

--- a/python/tests/test_deployable_component_logs.py
+++ b/python/tests/test_deployable_component_logs.py
@@ -1,0 +1,112 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import humps
+
+from hsml import deployable_component_logs
+import datetime
+
+
+class TestDeployableComponentLogs:
+
+    # from response json
+
+    def test_from_response_json(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_component_logs_single"][
+            "response"
+        ]
+        json_camelized = humps.camelize(json)
+        mocker_from_json = mocker.patch(
+            "hsml.deployable_component_logs.DeployableComponentLogs.from_json",
+            return_value=None,
+        )
+
+        # Act
+        dc_logs = deployable_component_logs.DeployableComponentLogs.from_response_json(
+            json_camelized
+        )
+
+        # Assert
+        assert isinstance(dc_logs, list)
+        assert len(dc_logs) == 1
+        mocker_from_json.assert_called_once_with(json[0])
+
+    def test_from_response_json_list(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_component_logs_list"][
+            "response"
+        ]
+        json_camelized = humps.camelize(json)
+        mocker_from_json = mocker.patch(
+            "hsml.deployable_component_logs.DeployableComponentLogs.from_json",
+            return_value=None,
+        )
+
+        # Act
+        dc_logs = deployable_component_logs.DeployableComponentLogs.from_response_json(
+            json_camelized
+        )
+
+        # Assert
+        assert isinstance(dc_logs, list)
+        assert len(dc_logs) == len(json_camelized)
+        assert mocker_from_json.call_count == len(json_camelized)
+
+    def test_from_response_json_empty(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_component_logs_empty"][
+            "response"
+        ]
+        json_camelized = humps.camelize(json)
+        mocker_from_json = mocker.patch(
+            "hsml.deployable_component_logs.DeployableComponentLogs.from_json",
+            return_value=None,
+        )
+
+        # Act
+        dc_logs = deployable_component_logs.DeployableComponentLogs.from_response_json(
+            json_camelized
+        )
+
+        # Assert
+        assert isinstance(dc_logs, list)
+        assert len(dc_logs) == 0
+        mocker_from_json.assert_not_called()
+
+    # constructor
+
+    def test_constructor(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_component_logs_single"][
+            "response"
+        ]
+        instance_name = json[0]["instance_name"]
+        content = json[0]["content"]
+        mock_now = datetime.datetime.now()
+
+        # Act
+        dcl = deployable_component_logs.DeployableComponentLogs(
+            instance_name=instance_name, content=content
+        )
+
+        # Assert
+        assert dcl.instance_name == instance_name
+        assert dcl.content == content
+        assert (
+            dcl.created_at > mock_now
+            and dcl.created_at < mock_now + datetime.timedelta(seconds=1)
+        )

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -15,17 +15,14 @@
 #
 
 import pytest
-
-from hsml import predictor, deployment
-from hsml.engine import serving_engine
-from hsml.core import serving_api
+from hsml import deployment, predictor
 from hsml.client.exceptions import ModelServingException
-
 from hsml.constants import PREDICTOR_STATE
+from hsml.core import serving_api
+from hsml.engine import serving_engine
 
 
 class TestDeployment:
-
     # from response json
 
     def test_from_response_json_list(self, mocker, backend_fixtures):
@@ -657,7 +654,7 @@ class TestDeployment:
         # Assert
         mock_util_get_members.assert_called_once()
         mock_serving_get_logs.assert_called_once_with(d, "predictor", 10)
-        mock_print.call_count == 2 * len(mock_logs)
+        assert mock_print.call_count == len(mock_logs)
 
     def test_get_logs_component_valid(self, mocker, backend_fixtures):
         # Arrange
@@ -684,7 +681,7 @@ class TestDeployment:
         # Assert
         mock_util_get_members.assert_called_once()
         mock_serving_get_logs.assert_called_once_with(d, "valid", 10)
-        mock_print.call_count == 2 * len(mock_logs)
+        assert mock_print.call_count == len(mock_logs)
 
     def test_get_logs_component_invalid(self, mocker, backend_fixtures):
         # Arrange
@@ -723,7 +720,7 @@ class TestDeployment:
         # Assert
         mock_util_get_members.assert_called_once()
         mock_serving_get_logs.assert_called_once_with(d, "predictor", 40)
-        mock_print.call_count == 2 * len(mock_logs)
+        assert mock_print.call_count == len(mock_logs)
 
     def test_get_logs_no_logs(self, mocker, backend_fixtures):
         # Arrange
@@ -745,7 +742,7 @@ class TestDeployment:
         # Assert
         mock_util_get_members.assert_called_once()
         mock_serving_get_logs.assert_called_once_with(d, "predictor", 10)
-        mock_print.call_count == 0
+        assert mock_print.call_count == 0
 
     # get url
 

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -1,0 +1,798 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+
+from hsml import predictor, deployment
+from hsml.engine import serving_engine
+from hsml.core import serving_api
+from hsml.client.exceptions import ModelServingException
+
+from hsml.constants import PREDICTOR_STATE
+
+
+class TestDeployment:
+
+    # from response json
+
+    def test_from_response_json_list(self, mocker, backend_fixtures):
+        # Arrange
+        preds = [{"name": "pred_name"}]
+        mock_pred_from_response_json = mocker.patch(
+            "hsml.predictor.Predictor.from_response_json",
+            return_value=preds,
+        )
+        mock_from_predictor = mocker.patch(
+            "hsml.deployment.Deployment.from_predictor", return_value=preds[0]
+        )
+
+        # Act
+        depl = deployment.Deployment.from_response_json(preds)
+
+        # Assert
+        assert isinstance(depl, list)
+        assert depl[0] == preds[0]
+        mock_pred_from_response_json.assert_called_once_with(preds)
+        mock_from_predictor.assert_called_once_with(preds[0])
+
+    def test_from_response_json_single(self, mocker, backend_fixtures):
+        # Arrange
+        pred = {"name": "pred_name"}
+        mock_pred_from_response_json = mocker.patch(
+            "hsml.predictor.Predictor.from_response_json",
+            return_value=pred,
+        )
+        mock_from_predictor = mocker.patch(
+            "hsml.deployment.Deployment.from_predictor", return_value=pred
+        )
+
+        # Act
+        depl = deployment.Deployment.from_response_json(pred)
+
+        # Assert
+        assert depl == pred
+        mock_pred_from_response_json.assert_called_once_with(pred)
+        mock_from_predictor.assert_called_once_with(pred)
+
+    # constructor
+
+    def test_constructor_default(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+
+        # Act
+        d = deployment.Deployment(predictor=p)
+
+        # Assert
+        assert d.name == p.name
+        assert d.description == p.description
+        assert d.predictor == p
+        assert isinstance(d._serving_api, serving_api.ServingApi)
+        assert isinstance(d._serving_engine, serving_engine.ServingEngine)
+
+    def test_constructor(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+
+        # Act
+        d = deployment.Deployment(predictor=p, name=p.name, description=p.description)
+
+        # Assert
+        assert d.name == p.name
+        assert d.description == p.description
+        assert d.predictor == p
+        assert isinstance(d._serving_api, serving_api.ServingApi)
+        assert isinstance(d._serving_engine, serving_engine.ServingEngine)
+
+    def test_constructor_no_predictor(self):
+        # Act
+        with pytest.raises(ModelServingException) as e_info:
+            _ = deployment.Deployment(predictor=None)
+
+        # Assert
+        assert "A predictor is required" in str(e_info.value)
+
+    def test_constructor_wrong_predictor(self):
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = deployment.Deployment(predictor={"wrong": "type"})
+
+        # Assert
+        assert "not an instance of the Predictor class" in str(e_info.value)
+
+    # from predictor
+
+    def test_from_predictor(self, mocker):
+        # Arrange
+        class MockPredictor:
+            _name = "name"
+            _description = "description"
+
+        p = MockPredictor()
+        mock_deployment_init = mocker.patch(
+            "hsml.deployment.Deployment.__init__", return_value=None
+        )
+
+        # Act
+        deployment.Deployment.from_predictor(p)
+
+        # Assert
+        mock_deployment_init.assert_called_once_with(
+            predictor=p, name=p._name, description=p._description
+        )
+
+    # save
+
+    def test_save_default(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_save = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.save"
+        )
+
+        # Act
+        d.save()
+
+        # Assert
+        mock_serving_engine_save.assert_called_once_with(d, 60)
+
+    def test_save(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_save = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.save"
+        )
+
+        # Act
+        await_update = 120
+        d.save(await_update=await_update)
+
+        # Assert
+        mock_serving_engine_save.assert_called_once_with(d, await_update)
+
+    # start
+
+    def test_start_default(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_start = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.start"
+        )
+
+        # Act
+        d.start()
+
+        # Assert
+        mock_serving_engine_start.assert_called_once_with(d, await_status=60)
+
+    def test_start(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_start = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.start"
+        )
+
+        # Act
+        await_running = 120
+        d.start(await_running=await_running)
+
+        # Assert
+        mock_serving_engine_start.assert_called_once_with(d, await_status=await_running)
+
+    # stop
+
+    def test_stop_default(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_stop = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.stop"
+        )
+
+        # Act
+        d.stop()
+
+        # Assert
+        mock_serving_engine_stop.assert_called_once_with(d, await_status=60)
+
+    def test_stop(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_start = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.stop"
+        )
+
+        # Act
+        await_stopped = 120
+        d.stop(await_stopped=await_stopped)
+
+        # Assert
+        mock_serving_engine_start.assert_called_once_with(d, await_status=await_stopped)
+
+    # delete
+
+    def test_delete_default(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_delete = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.delete"
+        )
+
+        # Act
+        d.delete()
+
+        # Assert
+        mock_serving_engine_delete.assert_called_once_with(d, False)
+
+    def test_delete(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_delete = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.delete"
+        )
+
+        # Act
+        force = True
+        d.delete(force=force)
+
+        # Assert
+        mock_serving_engine_delete.assert_called_once_with(d, force)
+
+    # get state
+
+    def test_get_state(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_get_state = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_state"
+        )
+
+        # Act
+        d.get_state()
+
+        # Assert
+        mock_serving_engine_get_state.assert_called_once_with(d)
+
+    # status
+
+    # - is created
+
+    def test_is_created_false(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_state",
+            return_value=MockPredictorState(PREDICTOR_STATE.STATUS_CREATING),
+        )
+
+        # Act
+        is_created = d.is_created()
+
+        # Assert
+        assert not is_created
+
+    def test_is_created_true(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            PREDICTOR_STATE.STATUS_CREATED,
+            PREDICTOR_STATE.STATUS_FAILED,
+            PREDICTOR_STATE.STATUS_IDLE,
+            PREDICTOR_STATE.STATUS_RUNNING,
+            PREDICTOR_STATE.STATUS_STARTING,
+            PREDICTOR_STATE.STATUS_STOPPED,
+            PREDICTOR_STATE.STATUS_STOPPING,
+            PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert d.is_created()
+
+    # is running
+
+    def test_is_running_true(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_state",
+            return_value=MockPredictorState(PREDICTOR_STATE.STATUS_RUNNING),
+        )
+
+        # Act and Assert
+        assert d.is_running()
+
+    def test_is_running_false(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            PREDICTOR_STATE.STATUS_CREATED,
+            PREDICTOR_STATE.STATUS_CREATING,
+            PREDICTOR_STATE.STATUS_FAILED,
+            PREDICTOR_STATE.STATUS_IDLE,
+            PREDICTOR_STATE.STATUS_STARTING,
+            # PREDICTOR_STATE.STATUS_RUNNING,
+            PREDICTOR_STATE.STATUS_STOPPED,
+            PREDICTOR_STATE.STATUS_STOPPING,
+            PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert not d.is_running(or_idle=False, or_updating=False)
+
+    def test_is_running_or_idle_true(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            PREDICTOR_STATE.STATUS_IDLE,
+            PREDICTOR_STATE.STATUS_RUNNING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert d.is_running(or_idle=True)
+
+    def test_is_running_or_idle_false(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            PREDICTOR_STATE.STATUS_CREATED,
+            PREDICTOR_STATE.STATUS_CREATING,
+            PREDICTOR_STATE.STATUS_FAILED,
+            # PREDICTOR_STATE.STATUS_IDLE,
+            PREDICTOR_STATE.STATUS_STARTING,
+            # PREDICTOR_STATE.STATUS_RUNNING,
+            PREDICTOR_STATE.STATUS_STOPPED,
+            PREDICTOR_STATE.STATUS_STOPPING,
+            PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert not d.is_running(or_idle=True, or_updating=False)
+
+    def test_is_running_or_updating_true(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            # PREDICTOR_STATE.STATUS_CREATED,
+            # PREDICTOR_STATE.STATUS_CREATING,
+            # PREDICTOR_STATE.STATUS_FAILED,
+            # PREDICTOR_STATE.STATUS_IDLE,
+            # PREDICTOR_STATE.STATUS_STARTING,
+            PREDICTOR_STATE.STATUS_RUNNING,
+            # PREDICTOR_STATE.STATUS_STOPPED,
+            # PREDICTOR_STATE.STATUS_STOPPING,
+            PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert d.is_running(or_updating=True)
+
+    def test_is_running_or_updating_false(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            PREDICTOR_STATE.STATUS_CREATED,
+            PREDICTOR_STATE.STATUS_CREATING,
+            PREDICTOR_STATE.STATUS_FAILED,
+            PREDICTOR_STATE.STATUS_IDLE,
+            PREDICTOR_STATE.STATUS_STARTING,
+            # PREDICTOR_STATE.STATUS_RUNNING,
+            PREDICTOR_STATE.STATUS_STOPPED,
+            PREDICTOR_STATE.STATUS_STOPPING,
+            # PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert not d.is_running(or_idle=False, or_updating=True)
+
+    # - is stopped
+
+    def test_is_stopped_true(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_state",
+            return_value=MockPredictorState(PREDICTOR_STATE.STATUS_STOPPED),
+        )
+
+        # Act and Assert
+        assert d.is_stopped()
+
+    def test_is_stopped_false(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            PREDICTOR_STATE.STATUS_CREATED,
+            PREDICTOR_STATE.STATUS_CREATING,
+            PREDICTOR_STATE.STATUS_FAILED,
+            PREDICTOR_STATE.STATUS_IDLE,
+            PREDICTOR_STATE.STATUS_STARTING,
+            PREDICTOR_STATE.STATUS_RUNNING,
+            # PREDICTOR_STATE.STATUS_STOPPED,
+            PREDICTOR_STATE.STATUS_STOPPING,
+            PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert not d.is_stopped(or_created=False)
+
+    def test_is_stopped_or_created_true(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            PREDICTOR_STATE.STATUS_CREATED,
+            PREDICTOR_STATE.STATUS_CREATING,
+            # PREDICTOR_STATE.STATUS_FAILED,
+            # PREDICTOR_STATE.STATUS_IDLE,
+            # PREDICTOR_STATE.STATUS_STARTING,
+            # PREDICTOR_STATE.STATUS_RUNNING,
+            PREDICTOR_STATE.STATUS_STOPPED,
+            # PREDICTOR_STATE.STATUS_STOPPING,
+            # PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert d.is_stopped(or_created=True)
+
+    def test_is_stopped_or_created_false(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockPredictorState:
+            def __init__(self, status):
+                self.status = status
+
+        valid_statuses = [
+            # PREDICTOR_STATE.STATUS_CREATED,
+            # PREDICTOR_STATE.STATUS_CREATING,
+            PREDICTOR_STATE.STATUS_FAILED,
+            PREDICTOR_STATE.STATUS_IDLE,
+            PREDICTOR_STATE.STATUS_STARTING,
+            PREDICTOR_STATE.STATUS_RUNNING,
+            # PREDICTOR_STATE.STATUS_STOPPED,
+            PREDICTOR_STATE.STATUS_STOPPING,
+            PREDICTOR_STATE.STATUS_UPDATING,
+        ]
+
+        for valid_status in valid_statuses:
+            mocker.patch(
+                "hsml.engine.serving_engine.ServingEngine.get_state",
+                return_value=MockPredictorState(valid_status),
+            )
+
+            # Act and Assert
+            assert not d.is_stopped(or_created=True)
+
+    # predict
+
+    def test_predict(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_predict = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.predict"
+        )
+
+        # Act
+        d.predict("data", "inputs")
+
+        # Assert
+        mock_serving_engine_predict.assert_called_once_with(d, "data", "inputs")
+
+    # download artifact
+
+    def test_download_artifact(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_download_artifact = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.download_artifact"
+        )
+
+        # Act
+        d.download_artifact()
+
+        # Assert
+        mock_serving_engine_download_artifact.assert_called_once_with(d)
+
+    # get logs
+
+    def test_get_logs_default(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_util_get_members = mocker.patch(
+            "hsml.util.get_members", return_value=["predictor"]
+        )
+        mock_print = mocker.patch("builtins.print")
+
+        class MockLogs:
+            instance_name = "instance_name"
+            content = "content"
+
+        mock_logs = [MockLogs()]
+        mock_serving_get_logs = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_logs",
+            return_value=mock_logs,
+        )
+
+        # Act
+        d.get_logs()
+
+        # Assert
+        mock_util_get_members.assert_called_once()
+        mock_serving_get_logs.assert_called_once_with(d, "predictor", 10)
+        mock_print.call_count == 2 * len(mock_logs)
+
+    def test_get_logs_component_valid(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_util_get_members = mocker.patch(
+            "hsml.util.get_members", return_value=["valid"]
+        )
+        mock_print = mocker.patch("builtins.print")
+
+        class MockLogs:
+            instance_name = "instance_name"
+            content = "content"
+
+        mock_logs = [MockLogs()]
+        mock_serving_get_logs = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_logs",
+            return_value=mock_logs,
+        )
+
+        # Act
+        d.get_logs(component="valid")
+
+        # Assert
+        mock_util_get_members.assert_called_once()
+        mock_serving_get_logs.assert_called_once_with(d, "valid", 10)
+        mock_print.call_count == 2 * len(mock_logs)
+
+    def test_get_logs_component_invalid(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            d.get_logs(component="invalid")
+
+        # Assert
+        assert "is not valid" in str(e_info.value)
+
+    def test_get_logs_tail(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_util_get_members = mocker.patch(
+            "hsml.util.get_members", return_value=["predictor"]
+        )
+        mock_print = mocker.patch("builtins.print")
+
+        class MockLogs:
+            instance_name = "instance_name"
+            content = "content"
+
+        mock_logs = [MockLogs()]
+        mock_serving_get_logs = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_logs",
+            return_value=mock_logs,
+        )
+
+        # Act
+        d.get_logs(tail=40)
+
+        # Assert
+        mock_util_get_members.assert_called_once()
+        mock_serving_get_logs.assert_called_once_with(d, "predictor", 40)
+        mock_print.call_count == 2 * len(mock_logs)
+
+    def test_get_logs_no_logs(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_util_get_members = mocker.patch(
+            "hsml.util.get_members", return_value=["predictor"]
+        )
+        mock_print = mocker.patch("builtins.print")
+
+        mock_serving_get_logs = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine.get_logs",
+            return_value=None,
+        )
+
+        # Act
+        d.get_logs()
+
+        # Assert
+        mock_util_get_members.assert_called_once()
+        mock_serving_get_logs.assert_called_once_with(d, "predictor", 10)
+        mock_print.call_count == 0
+
+    # get url
+
+    def test_get_url(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        class MockClient:
+            _project_id = "project_id"
+
+        mock_client = MockClient()
+        path = "/p/" + str(mock_client._project_id) + "/deployments/" + str(d.id)
+
+        mock_util_get_hostname_replaced_url = mocker.patch(
+            "hsml.util.get_hostname_replaced_url", return_value="url"
+        )
+        mock_client_get_instance = mocker.patch(
+            "hsml.client.get_instance", return_value=mock_client
+        )
+
+        # Act
+        url = d.get_url()
+
+        # Assert
+        assert url == "url"
+        mock_util_get_hostname_replaced_url.assert_called_once_with(path)
+        mock_client_get_instance.assert_called_once()
+
+    # auxiliary methods
+
+    def _get_dummy_predictor(self, mocker, backend_fixtures):
+        p_json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+            "items"
+        ][0]
+        mocker.patch("hsml.predictor.Predictor._validate_serving_tool")
+        mocker.patch("hsml.predictor.Predictor._validate_resources")
+        mocker.patch("hsml.predictor.Predictor._validate_script_file")
+        mocker.patch("hsml.util.get_obj_from_json")
+        return predictor.Predictor(
+            id=p_json["id"],
+            name=p_json["name"],
+            description=p_json["description"],
+            model_name=p_json["model_name"],
+            model_path=p_json["model_path"],
+            model_version=p_json["model_version"],
+            model_framework=p_json["model_framework"],
+            model_server=p_json["model_server"],
+            artifact_version=p_json["artifact_version"],
+        )

--- a/python/tests/test_inference_batcher.py
+++ b/python/tests/test_inference_batcher.py
@@ -14,15 +14,14 @@
 #   limitations under the License.
 #
 
-import humps
 import copy
 
+import humps
 from hsml import inference_batcher
 from hsml.constants import INFERENCE_BATCHER
 
 
 class TestInferenceBatcher:
-
     # from response json
 
     def test_from_response_json_enabled(self, mocker, backend_fixtures):

--- a/python/tests/test_inference_batcher.py
+++ b/python/tests/test_inference_batcher.py
@@ -1,0 +1,235 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import humps
+import copy
+
+from hsml import inference_batcher
+from hsml.constants import INFERENCE_BATCHER
+
+
+class TestInferenceBatcher:
+
+    # from response json
+
+    def test_from_response_json_enabled(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_ib_from_json = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.from_json"
+        )
+
+        # Act
+        _ = inference_batcher.InferenceBatcher.from_response_json(json_camelized)
+
+        # Assert
+        mock_ib_from_json.assert_called_once_with(json)
+
+    def test_from_response_json_enabled_with_config(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled_with_config"][
+            "response"
+        ]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_ib_from_json = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.from_json"
+        )
+
+        # Act
+        _ = inference_batcher.InferenceBatcher.from_response_json(json_camelized)
+
+        # Assert
+        mock_ib_from_json.assert_called_once_with(json)
+
+    # from json
+
+    def test_from_json_enabled(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled"]["response"]
+        mock_ib_extract_fields = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.extract_fields_from_json",
+            return_value=json,
+        )
+        mock_ib_init = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.__init__", return_value=None
+        )
+
+        # Act
+        _ = inference_batcher.InferenceBatcher.from_json(json)
+
+        # Assert
+        mock_ib_extract_fields.assert_called_once_with(json)
+        mock_ib_init.assert_called_once_with(**json)
+
+    def test_from_json_enabled_with_config(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled_with_config"][
+            "response"
+        ]
+        mock_ib_extract_fields = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.extract_fields_from_json",
+            return_value=json,
+        )
+        mock_ib_init = mocker.patch(
+            "hsml.inference_batcher.InferenceBatcher.__init__", return_value=None
+        )
+
+        # Act
+        _ = inference_batcher.InferenceBatcher.from_json(json)
+
+        # Assert
+        mock_ib_extract_fields.assert_called_once_with(json)
+        mock_ib_init.assert_called_once_with(**json)
+
+    # constructor
+
+    def test_constructor_default(self):
+        # Act
+        ib = inference_batcher.InferenceBatcher()
+
+        # Assert
+        assert isinstance(ib, inference_batcher.InferenceBatcher)
+        assert ib.enabled == INFERENCE_BATCHER.ENABLED
+        assert ib.max_batch_size is None
+        assert ib.max_latency is None
+        assert ib.timeout is None
+
+    def test_constructor_enabled(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled"]["response"]
+
+        # Act
+        ib = inference_batcher.InferenceBatcher(**json)
+
+        # Assert
+        assert isinstance(ib, inference_batcher.InferenceBatcher)
+        assert ib.enabled == json["enabled"]
+        assert ib.max_batch_size is None
+        assert ib.max_latency is None
+        assert ib.timeout is None
+
+    def test_constructor_enabled_with_config(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled_with_config"][
+            "response"
+        ]
+
+        # Act
+        ib = inference_batcher.InferenceBatcher(**json)
+
+        # Assert
+        assert isinstance(ib, inference_batcher.InferenceBatcher)
+        assert ib.enabled == json["enabled"]
+        assert ib.max_batch_size == json["max_batch_size"]
+        assert ib.max_latency == json["max_latency"]
+        assert ib.timeout == json["timeout"]
+
+    def test_constructor_disabled(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_disabled"]["response"]
+
+        # Act
+        ib = inference_batcher.InferenceBatcher(**json)
+
+        # Assert
+        assert isinstance(ib, inference_batcher.InferenceBatcher)
+        assert ib.enabled == json["enabled"]
+        assert ib.max_batch_size is None
+        assert ib.max_latency is None
+        assert ib.timeout is None
+
+    def test_constructor_disabled_with_config(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_disabled_with_config"][
+            "response"
+        ]
+
+        # Act
+        ib = inference_batcher.InferenceBatcher(**json)
+
+        # Assert
+        assert isinstance(ib, inference_batcher.InferenceBatcher)
+        assert ib.enabled == json["enabled"]
+        assert ib.max_batch_size == json["max_batch_size"]
+        assert ib.max_latency == json["max_latency"]
+        assert ib.timeout == json["timeout"]
+
+    # # extract fields from json
+
+    def test_extract_fields_from_json_enabled(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled"]["response"]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = inference_batcher.InferenceBatcher.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["enabled"] == json["enabled"]
+        assert kwargs["max_batch_size"] is None
+        assert kwargs["max_latency"] is None
+        assert kwargs["timeout"] is None
+
+    def test_extract_fields_from_json_enabled_with_config(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled_with_config"][
+            "response"
+        ]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = inference_batcher.InferenceBatcher.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["enabled"] == json["enabled"]
+        assert kwargs["max_batch_size"] == json["max_batch_size"]
+        assert kwargs["max_latency"] == json["max_latency"]
+        assert kwargs["timeout"] == json["timeout"]
+
+    def test_extract_fields_from_json_enabled_nested(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled"]["response_nested"]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = inference_batcher.InferenceBatcher.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["enabled"] == json["batching_configuration"]["enabled"]
+        assert kwargs["max_batch_size"] is None
+        assert kwargs["max_latency"] is None
+        assert kwargs["timeout"] is None
+
+    def test_extract_fields_from_json_enabled_with_config_nested(
+        self, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["inference_batcher"]["get_enabled_with_config"][
+            "response_nested"
+        ]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = inference_batcher.InferenceBatcher.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["enabled"] == json["batching_configuration"]["enabled"]
+        assert (
+            kwargs["max_batch_size"] == json["batching_configuration"]["max_batch_size"]
+        )
+        assert kwargs["max_latency"] == json["batching_configuration"]["max_latency"]
+        assert kwargs["timeout"] == json["batching_configuration"]["timeout"]

--- a/python/tests/test_inference_endpoint.py
+++ b/python/tests/test_inference_endpoint.py
@@ -1,0 +1,299 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import humps
+import copy
+
+from hsml import inference_endpoint
+
+
+class TestInferenceEndpoint:
+
+    # InferenceEndpointPort
+
+    # from response json
+
+    def test_from_response_json_port(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_port"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_ie_from_json = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpointPort.from_json"
+        )
+
+        # Act
+        _ = inference_endpoint.InferenceEndpointPort.from_response_json(json_camelized)
+
+        # Assert
+        mock_ie_from_json.assert_called_once_with(json)
+
+    # from json
+
+    def test_from_json_port(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_port"]["response"]
+        mock_ie_extract_fields = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpointPort.extract_fields_from_json",
+            return_value=json,
+        )
+        mock_ie_init = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpointPort.__init__", return_value=None
+        )
+
+        # Act
+        _ = inference_endpoint.InferenceEndpointPort.from_json(json)
+
+        # Assert
+        mock_ie_extract_fields.assert_called_once_with(json)
+        mock_ie_init.assert_called_once_with(**json)
+
+    # constructor
+
+    def test_constructor_port(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_port"]["response"]
+
+        # Act
+        ie_port = inference_endpoint.InferenceEndpointPort(
+            name=json["name"], number=json["number"]
+        )
+
+        # Assert
+        assert ie_port.name == json["name"]
+        assert ie_port.number == json["number"]
+
+    # extract fields from json
+
+    def test_extract_fields_from_json_port(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_port"]["response"]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = inference_endpoint.InferenceEndpointPort.extract_fields_from_json(
+            json_copy
+        )
+
+        # Assert
+        assert kwargs["name"] == json["name"]
+        assert kwargs["number"] == json["number"]
+
+    # InferenceEndpoint
+
+    # from response json
+
+    def test_from_response_json_empty(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_empty"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_ie_from_json = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpoint.from_json"
+        )
+
+        # Act
+        ie = inference_endpoint.InferenceEndpoint.from_response_json(json_camelized)
+
+        # Assert
+        assert isinstance(ie, list)
+        assert len(ie) == 0
+        mock_ie_from_json.assert_not_called()
+
+    def test_from_response_json_singleton(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_singleton"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_ie_from_json = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpoint.from_json"
+        )
+
+        # Act
+        ie = inference_endpoint.InferenceEndpoint.from_response_json(json_camelized)
+
+        # Assert
+        assert isinstance(ie, list)
+        assert len(ie) == 1
+        mock_ie_from_json.assert_called_once_with(json["items"][0])
+
+    def test_from_response_json_list(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_list"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_ie_from_json = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpoint.from_json"
+        )
+
+        # Act
+        ie = inference_endpoint.InferenceEndpoint.from_response_json(json_camelized)
+
+        # Assert
+        assert isinstance(ie, list)
+        assert len(ie) == json["count"]
+        mock_ie_from_json.call_count == json["count"]
+
+    def test_from_response_json_single(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_singleton"]["response"][
+            "items"
+        ][0]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_ie_from_json = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpoint.from_json"
+        )
+
+        # Act
+        _ = inference_endpoint.InferenceEndpoint.from_response_json(json_camelized)
+
+        # Assert
+        mock_ie_from_json.assert_called_once_with(json)
+
+    # from json
+
+    def test_from_json(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_singleton"]["response"][
+            "items"
+        ][0]
+        mock_ie_extract_fields = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpoint.extract_fields_from_json",
+            return_value=json,
+        )
+        mock_ie_init = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpoint.__init__", return_value=None
+        )
+
+        # Act
+        _ = inference_endpoint.InferenceEndpoint.from_json(json)
+
+        # Assert
+        mock_ie_extract_fields.assert_called_once_with(json)
+        mock_ie_init.assert_called_once_with(**json)
+
+    # constructor
+
+    def test_constructor(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_singleton"]["response"][
+            "items"
+        ][0]
+
+        # Act
+        ie = inference_endpoint.InferenceEndpoint(
+            type=json["type"], hosts=json["hosts"], ports=json["ports"]
+        )
+
+        # Assert
+        assert isinstance(ie, inference_endpoint.InferenceEndpoint)
+        assert ie.type == json["type"]
+        assert ie.hosts == json["hosts"]
+        assert ie.ports == json["ports"]
+
+    # extract fields from json
+
+    def test_extract_fields_from_json(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_singleton"]["response"][
+            "items"
+        ][0]
+        json_copy = copy.deepcopy(json)
+        mock_ie_port_from_json = mocker.patch(
+            "hsml.inference_endpoint.InferenceEndpointPort.from_json", return_value=None
+        )
+
+        # Act
+        kwargs = inference_endpoint.InferenceEndpoint.extract_fields_from_json(
+            json_copy
+        )
+
+        # Assert
+        assert kwargs["type"] == json["type"]
+        assert kwargs["hosts"] == json["hosts"]
+        mock_ie_port_from_json.assert_called_once_with(json["ports"][0])
+
+    # get any host
+
+    def test_get_any_host(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_singleton"]["response"][
+            "items"
+        ][0]
+        ie = inference_endpoint.InferenceEndpoint(
+            type=None, hosts=json["hosts"], ports=None
+        )
+        mocker_random_choice = mocker.patch("random.choice", return_value=None)
+
+        # Act
+        _ = ie.get_any_host()
+
+        # Assert
+        mocker_random_choice.assert_called_once_with(ie.hosts)
+
+    def test_get_any_host_none(self, mocker, backend_fixtures):
+        # Arrange
+        ie = inference_endpoint.InferenceEndpoint(type=None, hosts=None, ports=None)
+        mocker_random_choice = mocker.patch("random.choice", return_value=None)
+
+        # Act
+        host = ie.get_any_host()
+
+        # Assert
+        assert host is None
+        mocker_random_choice.assert_not_called()
+
+    # get port
+
+    def test_get_port_existing(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_list"]["response"]["items"][
+            1
+        ]
+        ports = [
+            inference_endpoint.InferenceEndpointPort(p["name"], p["number"])
+            for p in json["ports"]
+        ]
+        ie = inference_endpoint.InferenceEndpoint(type=None, hosts=None, ports=ports)
+
+        # Act
+        port = ie.get_port(ports[0].name)
+
+        # Assert
+        assert port == ports[0]
+
+    def test_get_port_not_found(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_endpoint"]["get_list"]["response"]["items"][
+            1
+        ]
+        ports = [
+            inference_endpoint.InferenceEndpointPort(p["name"], p["number"])
+            for p in json["ports"]
+        ]
+        ie = inference_endpoint.InferenceEndpoint(type=None, hosts=None, ports=ports)
+
+        # Act
+        port = ie.get_port("not_found")
+
+        # Assert
+        assert port is None
+
+    def test_get_port_none(self):
+        # Arrange
+        ie = inference_endpoint.InferenceEndpoint(type=None, hosts=None, ports=None)
+
+        # Act
+        port = ie.get_port("not_found")
+
+        # Assert
+        assert port is None

--- a/python/tests/test_inference_endpoint.py
+++ b/python/tests/test_inference_endpoint.py
@@ -14,14 +14,13 @@
 #   limitations under the License.
 #
 
-import humps
 import copy
 
+import humps
 from hsml import inference_endpoint
 
 
 class TestInferenceEndpoint:
-
     # InferenceEndpointPort
 
     # from response json
@@ -141,7 +140,7 @@ class TestInferenceEndpoint:
         # Assert
         assert isinstance(ie, list)
         assert len(ie) == json["count"]
-        mock_ie_from_json.call_count == json["count"]
+        assert mock_ie_from_json.call_count == json["count"]
 
     def test_from_response_json_single(self, mocker, backend_fixtures):
         # Arrange

--- a/python/tests/test_inference_logger.py
+++ b/python/tests/test_inference_logger.py
@@ -14,16 +14,15 @@
 #   limitations under the License.
 #
 
-import pytest
-import humps
 import copy
 
+import humps
+import pytest
 from hsml import inference_logger, kafka_topic
 from hsml.constants import DEFAULT, INFERENCE_LOGGER
 
 
 class TestInferenceLogger:
-
     # from response json
 
     def test_from_response_json_with_mode_only(self, mocker, backend_fixtures):

--- a/python/tests/test_inference_logger.py
+++ b/python/tests/test_inference_logger.py
@@ -1,0 +1,414 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import humps
+import copy
+
+from hsml import inference_logger, kafka_topic
+from hsml.constants import DEFAULT, INFERENCE_LOGGER
+
+
+class TestInferenceLogger:
+
+    # from response json
+
+    def test_from_response_json_with_mode_only(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_il_from_json = mocker.patch(
+            "hsml.inference_logger.InferenceLogger.from_json"
+        )
+
+        # Act
+        _ = inference_logger.InferenceLogger.from_response_json(json_camelized)
+
+        # Assert
+        mock_il_from_json.assert_called_once_with(json)
+
+    def test_from_response_json_with_mode_and_kafka_topic(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all_with_kafka_topic"][
+            "response"
+        ]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_il_from_json = mocker.patch(
+            "hsml.inference_logger.InferenceLogger.from_json"
+        )
+
+        # Act
+        _ = inference_logger.InferenceLogger.from_response_json(json_camelized)
+
+        # Assert
+        mock_il_from_json.assert_called_once_with(json)
+
+    # from json
+
+    def test_from_json_with_mode_all(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all"]["response"]
+        mock_il_extract_fields = mocker.patch(
+            "hsml.inference_logger.InferenceLogger.extract_fields_from_json",
+            return_value=json,
+        )
+        mock_il_init = mocker.patch(
+            "hsml.inference_logger.InferenceLogger.__init__", return_value=None
+        )
+
+        # Act
+        _ = inference_logger.InferenceLogger.from_json(json)
+
+        # Assert
+        mock_il_extract_fields.assert_called_once_with(json)
+        mock_il_init.assert_called_once_with(**json)
+
+    def test_from_json_with_mode_all_and_kafka_topic(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all_with_kafka_topic"][
+            "response"
+        ]
+        mock_il_extract_fields = mocker.patch(
+            "hsml.inference_logger.InferenceLogger.extract_fields_from_json",
+            return_value=json,
+        )
+        mock_il_init = mocker.patch(
+            "hsml.inference_logger.InferenceLogger.__init__", return_value=None
+        )
+
+        # Act
+        _ = inference_logger.InferenceLogger.from_json(json)
+
+        # Assert
+        mock_il_extract_fields.assert_called_once_with(json)
+        mock_il_init.assert_called_once_with(**json)
+
+    # constructor
+
+    def test_constructor_default(self, mocker):
+        # Arrange
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=INFERENCE_LOGGER.MODE_ALL,
+        )
+        default_kt = kafka_topic.KafkaTopic()
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=default_kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger()
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == INFERENCE_LOGGER.MODE_ALL
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == default_kt.name
+        assert il.kafka_topic.num_replicas == default_kt.num_replicas
+        assert il.kafka_topic.num_partitions == default_kt.num_partitions
+        mock_util_get_obj_from_json.assert_called_once_with(
+            DEFAULT, kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(
+            INFERENCE_LOGGER.MODE_ALL, default_kt
+        )
+
+    def test_constructor_mode_all(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all"]["init_args"]
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=json["mode"],
+        )
+        default_kt = kafka_topic.KafkaTopic()
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=default_kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger(**json)
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == json["mode"]
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == default_kt.name
+        assert il.kafka_topic.num_replicas == default_kt.num_replicas
+        assert il.kafka_topic.num_partitions == default_kt.num_partitions
+        mock_util_get_obj_from_json.assert_called_once_with(
+            DEFAULT, kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(json["mode"], default_kt)
+
+    def test_constructor_mode_inputs(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_inputs"]["init_args"]
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=json["mode"],
+        )
+        default_kt = kafka_topic.KafkaTopic()
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=default_kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger(**json)
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == json["mode"]
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == default_kt.name
+        assert il.kafka_topic.num_replicas == default_kt.num_replicas
+        assert il.kafka_topic.num_partitions == default_kt.num_partitions
+        mock_util_get_obj_from_json.assert_called_once_with(
+            DEFAULT, kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(json["mode"], default_kt)
+
+    def test_constructor_mode_outputs(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_outputs"]["init_args"]
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=json["mode"],
+        )
+        default_kt = kafka_topic.KafkaTopic()
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=default_kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger(**json)
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == json["mode"]
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == default_kt.name
+        assert il.kafka_topic.num_replicas == default_kt.num_replicas
+        assert il.kafka_topic.num_partitions == default_kt.num_partitions
+        mock_util_get_obj_from_json.assert_called_once_with(
+            DEFAULT, kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(json["mode"], default_kt)
+
+    def test_constructor_mode_all_and_kafka_topic(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all_with_kafka_topic"][
+            "init_args"
+        ]
+        json_copy = copy.deepcopy(json)
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=json["mode"],
+        )
+        kt = kafka_topic.KafkaTopic(json["kafka_topic"]["name"])
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger(**json_copy)
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == json["mode"]
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == kt.name
+        assert il.kafka_topic.num_replicas is None
+        assert il.kafka_topic.num_partitions is None
+        mock_util_get_obj_from_json.assert_called_once_with(
+            json["kafka_topic"], kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(json["mode"], kt)
+
+    def test_constructor_mode_inputs_and_kafka_topic(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_inputs_with_kafka_topic"][
+            "init_args"
+        ]
+        json_copy = copy.deepcopy(json)
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=json["mode"],
+        )
+        kt = kafka_topic.KafkaTopic(json["kafka_topic"]["name"])
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger(**json_copy)
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == json["mode"]
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == kt.name
+        assert il.kafka_topic.num_replicas is None
+        assert il.kafka_topic.num_partitions is None
+        mock_util_get_obj_from_json.assert_called_once_with(
+            json["kafka_topic"], kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(json["mode"], kt)
+
+    def test_constructor_mode_outputs_and_kafka_topic(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all_with_kafka_topic"][
+            "init_args"
+        ]
+        json_copy = copy.deepcopy(json)
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=json["mode"],
+        )
+        kt = kafka_topic.KafkaTopic(json["kafka_topic"]["name"])
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger(**json_copy)
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == json["mode"]
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == kt.name
+        assert il.kafka_topic.num_replicas is None
+        assert il.kafka_topic.num_partitions is None
+        mock_util_get_obj_from_json.assert_called_once_with(
+            json["kafka_topic"], kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(json["mode"], kt)
+
+    def test_constructor_mode_none_and_kafka_topic(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_none_with_kafka_topic"][
+            "init_args"
+        ]
+        json_copy = copy.deepcopy(json)
+        mock_il_validate_mode = mocker.patch(
+            "hsml.inference_logger.InferenceLogger._validate_mode",
+            return_value=json["mode"],
+        )
+        kt = kafka_topic.KafkaTopic(json["kafka_topic"]["name"])
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value=kt
+        )
+
+        # Act
+        il = inference_logger.InferenceLogger(**json_copy)
+
+        # Assert
+        assert isinstance(il, inference_logger.InferenceLogger)
+        assert il.mode == json["mode"]
+        assert isinstance(il.kafka_topic, kafka_topic.KafkaTopic)
+        assert il.kafka_topic.name == kt.name
+        assert il.kafka_topic.num_replicas is None
+        assert il.kafka_topic.num_partitions is None
+        mock_util_get_obj_from_json.assert_called_once_with(
+            json["kafka_topic"], kafka_topic.KafkaTopic
+        )
+        mock_il_validate_mode.assert_called_once_with(json["mode"], kt)
+
+    # validate mode
+
+    def test_validate_mode_none_and_kafka_topic_none(self):
+        # Act
+        mode = inference_logger.InferenceLogger._validate_mode(None, None)
+
+        # Assert
+        assert mode is None
+
+    def test_validate_mode_all_and_kafka_topic_none(self):
+        # Act
+        mode = inference_logger.InferenceLogger._validate_mode(
+            INFERENCE_LOGGER.MODE_ALL, None
+        )
+
+        # Assert
+        assert mode is None
+
+    def test_validate_mode_invalid_and_kafka_topic_none(self):
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = inference_logger.InferenceLogger._validate_mode("invalid", None)
+
+        # Assert
+        assert "is not valid" in str(e_info.value)
+
+    def test_validate_mode_none_and_kafka_topic(self):
+        # Act
+        mode = inference_logger.InferenceLogger._validate_mode(
+            None, kafka_topic.KafkaTopic()
+        )
+
+        # Assert
+        assert mode == INFERENCE_LOGGER.MODE_NONE
+
+    def test_validate_mode_all_and_kafka_topic(self):
+        # Act
+        mode = inference_logger.InferenceLogger._validate_mode(
+            INFERENCE_LOGGER.MODE_ALL, kafka_topic.KafkaTopic()
+        )
+
+        # Assert
+        assert mode == INFERENCE_LOGGER.MODE_ALL
+
+    def test_validate_mode_invalid_and_kafka_topic(self):
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = inference_logger.InferenceLogger._validate_mode(
+                "invalid", kafka_topic.KafkaTopic()
+            )
+
+        # Assert
+        assert "is not valid" in str(e_info.value)
+
+    # extract fields from json
+
+    def test_extract_fields_from_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all_with_kafka_topic"][
+            "response"
+        ]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = inference_logger.InferenceLogger.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["kafka_topic"] == json["kafka_topic_dto"]
+        assert kwargs["mode"] == json["inference_logging"]
+
+    def test_extract_fields_from_json_alternative(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["inference_logger"]["get_mode_all_with_kafka_topic"][
+            "init_args"
+        ]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = inference_logger.InferenceLogger.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["kafka_topic"] == json["kafka_topic"]
+        assert kwargs["mode"] == json["mode"]

--- a/python/tests/test_kafka_topic.py
+++ b/python/tests/test_kafka_topic.py
@@ -1,0 +1,290 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import humps
+import copy
+
+from hsml import kafka_topic
+from hsml.constants import KAFKA_TOPIC
+
+
+class TestKafkaTopic:
+
+    # from response json
+
+    def test_from_response_json_with_name_only(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_only"][
+            "response"
+        ]["kafka_topic_dto"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_kt_from_json = mocker.patch("hsml.kafka_topic.KafkaTopic.from_json")
+
+        # Act
+        _ = kafka_topic.KafkaTopic.from_response_json(json_camelized)
+
+        # Assert
+        mock_kt_from_json.assert_called_once_with(json)
+
+    def test_from_response_json_with_name_and_config(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_and_config"][
+            "response"
+        ]["kafka_topic_dto"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+        mock_kt_from_json = mocker.patch("hsml.kafka_topic.KafkaTopic.from_json")
+
+        # Act
+        _ = kafka_topic.KafkaTopic.from_response_json(json_camelized)
+
+        # Assert
+        mock_kt_from_json.assert_called_once_with(json)
+
+    # from json
+
+    def test_from_json_with_name_only(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_only"][
+            "response"
+        ]["kafka_topic_dto"]
+        mock_kt_extract_fields = mocker.patch(
+            "hsml.kafka_topic.KafkaTopic.extract_fields_from_json", return_value=json
+        )
+        mock_kt_init = mocker.patch(
+            "hsml.kafka_topic.KafkaTopic.__init__", return_value=None
+        )
+
+        # Act
+        _ = kafka_topic.KafkaTopic.from_response_json(json)
+
+        # Assert
+        mock_kt_extract_fields.assert_called_once_with(json)
+        mock_kt_init.assert_called_once_with(**json)
+
+    def test_from_json_with_name_and_config(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_and_config"][
+            "response"
+        ]["kafka_topic_dto"]
+        mock_kt_extract_fields = mocker.patch(
+            "hsml.kafka_topic.KafkaTopic.extract_fields_from_json", return_value=json
+        )
+        mock_kt_init = mocker.patch(
+            "hsml.kafka_topic.KafkaTopic.__init__", return_value=None
+        )
+
+        # Act
+        _ = kafka_topic.KafkaTopic.from_response_json(json)
+
+        # Assert
+        mock_kt_extract_fields.assert_called_once_with(json)
+        mock_kt_init.assert_called_once_with(**json)
+
+    # constructor
+
+    def test_constructor_existing_with_name_only(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_only"][
+            "response"
+        ]["kafka_topic_dto"]
+        mock_kt_validate_topic_config = mocker.patch(
+            "hsml.kafka_topic.KafkaTopic._validate_topic_config",
+            return_value=(KAFKA_TOPIC.NUM_REPLICAS, KAFKA_TOPIC.NUM_PARTITIONS),
+        )
+
+        # Act
+        kt = kafka_topic.KafkaTopic(**json)
+
+        # Assert
+        assert isinstance(kt, kafka_topic.KafkaTopic)
+        assert kt.name == json["name"]
+        assert kt.num_replicas == KAFKA_TOPIC.NUM_REPLICAS
+        assert kt.num_partitions == KAFKA_TOPIC.NUM_PARTITIONS
+        mock_kt_validate_topic_config.assert_called_once_with(json["name"], None, None)
+
+    def test_constructor_existing_with_name_and_config(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_and_config"][
+            "response"
+        ]["kafka_topic_dto"]
+        mock_kt_validate_topic_config = mocker.patch(
+            "hsml.kafka_topic.KafkaTopic._validate_topic_config",
+            return_value=(json["num_replicas"], json["num_partitions"]),
+        )
+
+        # Act
+        kt = kafka_topic.KafkaTopic(**json)
+
+        # Assert
+        assert isinstance(kt, kafka_topic.KafkaTopic)
+        assert kt.name == json["name"]
+        assert kt.num_replicas == json["num_replicas"]
+        assert kt.num_partitions == json["num_partitions"]
+        mock_kt_validate_topic_config.assert_called_once_with(
+            json["name"], json["num_replicas"], json["num_partitions"]
+        )
+
+    # validate topic config
+
+    def test_validate_topic_config_existing_with_name_only(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_only"][
+            "response"
+        ]["kafka_topic_dto"]
+
+        # Act
+        num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+            json["name"], None, None
+        )
+
+        # Assert
+        assert num_repl is None
+        assert num_part is None
+
+    def test_validate_topic_config_existing_with_name_and_config(
+        self, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_and_config"][
+            "response"
+        ]["kafka_topic_dto"]
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+                json["name"], json["num_replicas"], json["num_partitions"]
+            )
+
+        # Assert
+        assert "Number of replicas or partitions cannot be changed" in str(e_info.value)
+
+    def test_validate_topic_config_none(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_none"]["response"][
+            "kafka_topic_dto"
+        ]
+
+        # Act
+        num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+            json["name"], None, None
+        )
+
+        # Assert
+        assert num_repl is None
+        assert num_part is None
+
+    def test_validate_topic_config_none_with_config(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_none_with_config"]["response"][
+            "kafka_topic_dto"
+        ]
+
+        # Act
+        num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+            json["name"], json["num_replicas"], json["num_partitions"]
+        )
+
+        # Assert
+        assert num_repl is None
+        assert num_part is None
+
+    def test_validate_topic_config_none_value(self):
+        # Act
+        num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+            None, None, None
+        )
+
+        # Assert
+        assert num_repl is None
+        assert num_part is None
+
+    def test_validate_topic_config_none_value_with_config(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_none_with_config"]["response"][
+            "kafka_topic_dto"
+        ]
+
+        # Act
+        num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+            None, json["num_replicas"], json["num_partitions"]
+        )
+
+        # Assert
+        assert num_repl is None
+        assert num_part is None
+
+    def test_validate_topic_config_create(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_create_with_name_only"]["response"][
+            "kafka_topic_dto"
+        ]
+
+        # Act
+        num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+            json["name"], None, None
+        )
+
+        # Assert
+        assert num_repl == KAFKA_TOPIC.NUM_REPLICAS
+        assert num_part == KAFKA_TOPIC.NUM_PARTITIONS
+
+    def test_validate_topic_config_create_with_config(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_create_with_name_and_config"][
+            "response"
+        ]["kafka_topic_dto"]
+
+        # Act
+        num_repl, num_part = kafka_topic.KafkaTopic._validate_topic_config(
+            json["name"], json["num_replicas"], json["num_partitions"]
+        )
+
+        # Assert
+        assert num_repl == json["num_replicas"]
+        assert num_part == json["num_partitions"]
+
+    # extract fields from json
+
+    def test_extract_fields_from_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"]["get_existing_with_name_and_config"][
+            "response"
+        ]["kafka_topic_dto"]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = kafka_topic.KafkaTopic.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["name"] == json["name"]
+        assert kwargs["num_replicas"] == json["num_replicas"]
+        assert kwargs["num_partitions"] == json["num_partitions"]
+
+    def test_extract_fields_from_json_alternative(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["kafka_topic"][
+            "get_existing_with_name_and_config_alternative"
+        ]["response"]["kafka_topic_dto"]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        kwargs = kafka_topic.KafkaTopic.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert kwargs["name"] == json["name"]
+        assert kwargs["num_replicas"] == json["num_of_replicas"]
+        assert kwargs["num_partitions"] == json["num_of_partitions"]

--- a/python/tests/test_kafka_topic.py
+++ b/python/tests/test_kafka_topic.py
@@ -14,16 +14,15 @@
 #   limitations under the License.
 #
 
-import pytest
-import humps
 import copy
 
+import humps
+import pytest
 from hsml import kafka_topic
 from hsml.constants import KAFKA_TOPIC
 
 
 class TestKafkaTopic:
-
     # from response json
 
     def test_from_response_json_with_name_only(self, mocker, backend_fixtures):

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -14,17 +14,16 @@
 #   limitations under the License.
 #
 
-import pytest
-import humps
 import copy
 
+import humps
+import pytest
 from hsml import model
 from hsml.constants import MODEL
 from hsml.core import explicit_provenance
 
 
 class TestModel:
-
     # from response json
 
     def test_from_response_json_empty(self, backend_fixtures):

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -1,0 +1,490 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import humps
+import copy
+
+from hsml import model
+from hsml.constants import MODEL
+from hsml.core import explicit_provenance
+
+
+class TestModel:
+
+    # from response json
+
+    def test_from_response_json_empty(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_empty"]["response"]
+
+        # Act
+        m_lst = model.Model.from_response_json(json)
+
+        # Assert
+        assert isinstance(m_lst, list)
+        assert len(m_lst) == 0
+
+    def test_from_response_json_singleton(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_python"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+
+        # Act
+        m = model.Model.from_response_json(copy.deepcopy(json_camelized))
+
+        # Assert
+        assert isinstance(m, list)
+        assert len(m) == 1
+
+        m = m[0]
+        m_json = json["items"][0]
+
+        self.assert_model(mocker, m, m_json, MODEL.FRAMEWORK_PYTHON)
+
+    def test_from_response_json_list(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_list"]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+
+        # Act
+        m_lst = model.Model.from_response_json(copy.deepcopy(json_camelized))
+
+        # Assert
+        assert isinstance(m_lst, list)
+        assert len(m_lst) == 2
+
+        for i in range(len(m_lst)):
+            m = m_lst[i]
+            m_json = json["items"][i]
+            self.assert_model(mocker, m, m_json, MODEL.FRAMEWORK_PYTHON)
+
+    # constructor
+
+    def test_constructor_base(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_base"]["response"]["items"][0]
+        m_json = copy.deepcopy(json)
+        id = m_json.pop("id")
+        name = m_json.pop("name")
+
+        # Act
+        m = model.Model(id=id, name=name, **m_json)
+
+        # Assert
+        self.assert_model(mocker, m, json, None)
+
+    def test_constructor_python(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        m_json = copy.deepcopy(json)
+        id = m_json.pop("id")
+        name = m_json.pop("name")
+
+        # Act
+        m = model.Model(id=id, name=name, **m_json)
+
+        # Assert
+        self.assert_model(mocker, m, json, MODEL.FRAMEWORK_PYTHON)
+
+    def test_constructor_sklearn(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_sklearn"]["response"]["items"][0]
+        m_json = copy.deepcopy(json)
+        id = m_json.pop("id")
+        name = m_json.pop("name")
+
+        # Act
+        m = model.Model(id=id, name=name, **m_json)
+
+        # Assert
+        self.assert_model(mocker, m, json, MODEL.FRAMEWORK_SKLEARN)
+
+    def test_constructor_tensorflow(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_tensorflow"]["response"]["items"][0]
+        m_json = copy.deepcopy(json)
+        id = m_json.pop("id")
+        name = m_json.pop("name")
+
+        # Act
+        m = model.Model(id=id, name=name, **m_json)
+
+        # Assert
+        self.assert_model(mocker, m, json, MODEL.FRAMEWORK_TENSORFLOW)
+
+    def test_constructor_torch(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_torch"]["response"]["items"][0]
+        m_json = copy.deepcopy(json)
+        id = m_json.pop("id")
+        name = m_json.pop("name")
+
+        # Act
+        m = model.Model(id=id, name=name, **m_json)
+
+        # Assert
+        self.assert_model(mocker, m, json, MODEL.FRAMEWORK_TORCH)
+
+    # save
+
+    def test_save(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_save = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.save"
+        )
+        upload_configuration = {"config": "value"}
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.save(
+            model_path="model_path",
+            await_registration=1234,
+            keep_original_files=True,
+            upload_configuration=upload_configuration,
+        )
+
+        # Assert
+        mock_model_engine_save.assert_called_once_with(
+            model_instance=m,
+            model_path="model_path",
+            await_registration=1234,
+            keep_original_files=True,
+            upload_configuration=upload_configuration,
+        )
+
+    # deploy
+
+    def test_deploy(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        p_json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+            "items"
+        ][0]
+        mock_predictor = mocker.Mock()
+        mock_predictor_for_model = mocker.patch(
+            "hsml.predictor.Predictor.for_model", return_value=mock_predictor
+        )
+        # params
+        resources = copy.deepcopy(p_json["predictor_resources"])
+        inference_logger = {
+            "mode": p_json["inference_logging"],
+            "kafka_topic": copy.deepcopy(p_json["kafka_topic_dto"]),
+        }
+        inference_batcher = copy.deepcopy(p_json["batching_configuration"])
+        transformer = {
+            "script_file": p_json["transformer"],
+            "resources": copy.deepcopy(p_json["transformer_resources"]),
+        }
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.deploy(
+            name=p_json["name"],
+            description=p_json["description"],
+            artifact_version=p_json["artifact_version"],
+            serving_tool=p_json["serving_tool"],
+            script_file=p_json["predictor"],
+            resources=resources,
+            inference_logger=inference_logger,
+            inference_batcher=inference_batcher,
+            transformer=transformer,
+            api_protocol=p_json["api_protocol"],
+        )
+
+        # Assert
+        mock_predictor_for_model.assert_called_once_with(
+            m,
+            name=p_json["name"],
+            description=p_json["description"],
+            artifact_version=p_json["artifact_version"],
+            serving_tool=p_json["serving_tool"],
+            script_file=p_json["predictor"],
+            resources=resources,
+            inference_logger=inference_logger,
+            inference_batcher=inference_batcher,
+            transformer=transformer,
+            api_protocol=p_json["api_protocol"],
+        )
+        mock_predictor.deploy.assert_called_once()
+
+    # delete
+
+    def test_delete(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_delete = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.delete"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.delete()
+
+        # Assert
+        mock_model_engine_delete.assert_called_once_with(model_instance=m)
+
+    # download
+
+    def test_download(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_download = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.download"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.download()
+
+        # Assert
+        mock_model_engine_download.assert_called_once_with(model_instance=m)
+
+    # tags
+
+    def test_get_tag(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_get_tag = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.get_tag"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.get_tag("tag_name")
+
+        # Assert
+        mock_model_engine_get_tag.assert_called_once_with(
+            model_instance=m, name="tag_name"
+        )
+
+    def test_get_tags(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_get_tags = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.get_tags"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.get_tags()
+
+        # Assert
+        mock_model_engine_get_tags.assert_called_once_with(model_instance=m)
+
+    def test_set_tag(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_set_tag = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.set_tag"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.set_tag("tag_name", "tag_value")
+
+        # Assert
+        mock_model_engine_set_tag.assert_called_once_with(
+            model_instance=m, name="tag_name", value="tag_value"
+        )
+
+    def test_delete_tag(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_delete_tag = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.delete_tag"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.delete_tag("tag_name")
+
+        # Assert
+        mock_model_engine_delete_tag.assert_called_once_with(
+            model_instance=m, name="tag_name"
+        )
+
+    # get url
+
+    def test_get_url(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+
+        class ClientMock:
+            _project_id = 1
+
+        mock_client_get_instance = mocker.patch(
+            "hsml.client.get_instance", return_value=ClientMock()
+        )
+        mock_util_get_hostname_replaced_url = mocker.patch(
+            "hsml.util.get_hostname_replaced_url", return_value="full_path"
+        )
+        path_arg = "/p/1/models/" + m_json["name"] + "/" + str(m_json["version"])
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        url = m.get_url()
+
+        # Assert
+        assert url == "full_path"
+        mock_client_get_instance.assert_called_once()
+        mock_util_get_hostname_replaced_url.assert_called_once_with(sub_path=path_arg)
+
+    # get feature view
+
+    def test_get_feature_view_none(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_get_feature_view_provenance = mocker.patch(
+            "hsml.model.Model.get_feature_view_provenance", return_value=None
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        fv = m.get_feature_view()
+
+        # Assert
+        assert fv is None
+        mock_get_feature_view_provenance.assert_called_once()
+
+    def test_get_feature_view(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_fv = mocker.MagicMock()
+        mock_get_feature_view_provenance = mocker.patch(
+            "hsml.model.Model.get_feature_view_provenance", return_value=mock_fv
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        fv = m.get_feature_view()
+
+        # Assert
+        assert fv == mock_fv
+        mock_get_feature_view_provenance.assert_called_once()
+
+    def test_get_feature_view_prov_artifact(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_fv = mocker.MagicMock(spec=explicit_provenance.Artifact)
+        mock_fv.meta_type = "meta_type"
+        mocker.patch(
+            "hsml.model.Model.get_feature_view_provenance", return_value=mock_fv
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        with pytest.raises(Exception) as e_info:
+            _ = m.get_feature_view()
+
+        # Assert
+        assert "The returned object is not a valid feature view" in str(e_info.value)
+
+    # get feature view provenance
+
+    def test_get_feature_view_provenance(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_get_feature_view_provenance = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.get_feature_view_provenance"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.get_feature_view_provenance()
+
+        # Assert
+        mock_model_engine_get_feature_view_provenance.assert_called_once_with(
+            model_instance=m
+        )
+
+    # get training dataset provenance
+
+    def test_get_training_dataset_provenance(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_model_engine_get_training_dataset_provenance = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.get_training_dataset_provenance"
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.get_training_dataset_provenance()
+
+        # Assert
+        mock_model_engine_get_training_dataset_provenance.assert_called_once_with(
+            model_instance=m
+        )
+
+    # auxiliary methods
+
+    def assert_model(self, mocker, m, m_json, model_framework):
+        assert isinstance(m, model.Model)
+        assert m.id == m_json["id"]
+        assert m.name == m_json["name"]
+        assert m.version == m_json["version"]
+        assert m.created == m_json["created"]
+        assert m.creator == m_json["creator"]
+        assert m.description == m_json["description"]
+        assert m.experiment_id == m_json["experiment_id"]
+        assert m.project_name == m_json["project_name"]
+        assert m.experiment_project_name == m_json["experiment_project_name"]
+        assert m.training_metrics == m_json["metrics"]
+        assert m._user_full_name == m_json["user_full_name"]
+        assert m.training_dataset == m_json["training_dataset"]
+        assert m.model_registry_id == m_json["model_registry_id"]
+
+        if model_framework is None:
+            assert m.framework is None
+        else:
+            assert m.framework == model_framework
+
+        mock_read_json = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.read_json",
+            return_value="input_example_content",
+        )
+        assert m.input_example == "input_example_content"
+        mock_read_json.assert_called_once_with(
+            model_instance=m, resource=m_json["input_example"]
+        )
+
+        mock_read_json = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.read_json",
+            return_value="model_schema_content",
+        )
+        assert m.model_schema == "model_schema_content"
+        mock_read_json.assert_called_once_with(
+            model_instance=m, resource=m_json["model_schema"]
+        )
+
+        mock_read_file = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.read_file",
+            return_value="program_file_content",
+        )
+        assert m.program == "program_file_content"
+        mock_read_file.assert_called_once_with(
+            model_instance=m, resource=m_json["program"]
+        )
+
+        mock_read_file = mocker.patch(
+            "hsml.engine.model_engine.ModelEngine.read_file",
+            return_value="env_file_content",
+        )
+        assert m.environment == "env_file_content"
+        mock_read_file.assert_called_once_with(
+            model_instance=m, resource=m_json["environment"]
+        )

--- a/python/tests/test_model_schema.py
+++ b/python/tests/test_model_schema.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2022 Hopsworks AB
+#   Copyright 2024 Hopsworks AB
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ from hsml import model_schema
 
 
 class TestModelSchema:
-
     # constructor
 
     def test_constructor(self):

--- a/python/tests/test_model_schema.py
+++ b/python/tests/test_model_schema.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2021 Logical Clocks AB
+#   Copyright 2022 Hopsworks AB
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -13,3 +13,19 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
+
+from hsml import model_schema
+
+
+class TestModelSchema:
+
+    # constructor
+
+    def test_constructor(self):
+        # Act
+        msch = model_schema.ModelSchema(input_schema="1234", output_schema="4321")
+
+        # Assert
+        assert msch.input_schema == "1234"
+        assert msch.output_schema == "4321"

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -14,18 +14,19 @@
 #   limitations under the License.
 #
 
-import pytest
 import copy
 
+import pytest
 from hsml import (
+    inference_batcher,
+    inference_logger,
     predictor,
     resources,
     transformer,
-    inference_logger,
-    inference_batcher,
     util,
 )
-from hsml.constants import PREDICTOR, MODEL, RESOURCES
+from hsml.constants import MODEL, PREDICTOR, RESOURCES
+
 
 SERVING_RESOURCE_LIMITS = {"cores": 2, "memory": 1024, "gpus": 2}
 SERVING_NUM_INSTANCES_NO_LIMIT = [-1]
@@ -34,7 +35,6 @@ SERVING_NUM_INSTANCES_ONE = [0]
 
 
 class TestPredictor:
-
     # from response json
 
     def test_from_response_json_empty(self, mocker, backend_fixtures):

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1,0 +1,703 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import copy
+
+from hsml import (
+    predictor,
+    resources,
+    transformer,
+    inference_logger,
+    inference_batcher,
+    util,
+)
+from hsml.constants import PREDICTOR, MODEL, RESOURCES
+
+SERVING_RESOURCE_LIMITS = {"cores": 2, "memory": 1024, "gpus": 2}
+SERVING_NUM_INSTANCES_NO_LIMIT = [-1]
+SERVING_NUM_INSTANCES_SCALE_TO_ZERO = [0]
+SERVING_NUM_INSTANCES_ONE = [0]
+
+
+class TestPredictor:
+
+    # from response json
+
+    def test_from_response_json_empty(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        json = backend_fixtures["predictor"]["get_deployments_empty"]["response"]
+
+        # Act
+        pred = predictor.Predictor.from_response_json(json)
+
+        # Assert
+        assert isinstance(pred, list)
+        assert len(pred) == 0
+
+    def test_from_response_json_singleton(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"]
+
+        # Act
+        pred = predictor.Predictor.from_response_json(json)
+
+        # Assert
+        assert isinstance(pred, list)
+        assert len(pred) == 1
+
+        p = pred[0]
+        p_json = json["items"][0]
+
+        assert isinstance(p, predictor.Predictor)
+        assert p.id == p_json["id"]
+        assert p.name == p_json["name"]
+        assert p.description == p_json["description"]
+        assert p.created_at == p_json["created"]
+        assert p.creator == p_json["creator"]
+        assert p.model_path == p_json["model_path"]
+        assert p.model_name == p_json["model_name"]
+        assert p.model_version == p_json["model_version"]
+        assert p.model_framework == p_json["model_framework"]
+        assert p.model_server == p_json["model_server"]
+        assert p.serving_tool == p_json["serving_tool"]
+        assert p.api_protocol == p_json["api_protocol"]
+        assert p.artifact_version == p_json["artifact_version"]
+        assert p.script_file == p_json["predictor"]
+        assert isinstance(p.resources, resources.PredictorResources)
+        assert isinstance(p.transformer, transformer.Transformer)
+        assert p.transformer.script_file == p_json["transformer"]
+        assert isinstance(p.transformer.resources, resources.TransformerResources)
+        assert isinstance(p.inference_logger, inference_logger.InferenceLogger)
+        assert p.inference_logger.mode == p_json["inference_logging"]
+        assert isinstance(p.inference_batcher, inference_batcher.InferenceBatcher)
+        assert p.inference_batcher.enabled == bool(
+            p_json["batching_configuration"]["batching_enabled"]
+        )
+
+    def test_from_response_json_list(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        json = backend_fixtures["predictor"]["get_deployments_list"]["response"]
+
+        # Act
+        pred = predictor.Predictor.from_response_json(json)
+
+        # Assert
+        assert isinstance(pred, list)
+        assert len(pred) == 2
+
+        for i in range(len(pred)):
+            p = pred[i]
+            p_json = json["items"][i]
+
+            assert isinstance(p, predictor.Predictor)
+            assert p.id == p_json["id"]
+            assert p.name == p_json["name"]
+            assert p.description == p_json["description"]
+            assert p.created_at == p_json["created"]
+            assert p.creator == p_json["creator"]
+            assert p.model_path == p_json["model_path"]
+            assert p.model_name == p_json["model_name"]
+            assert p.model_version == p_json["model_version"]
+            assert p.model_framework == p_json["model_framework"]
+            assert p.model_server == p_json["model_server"]
+            assert p.serving_tool == p_json["serving_tool"]
+            assert p.api_protocol == p_json["api_protocol"]
+            assert p.artifact_version == p_json["artifact_version"]
+            assert p.script_file == p_json["predictor"]
+            assert isinstance(p.resources, resources.PredictorResources)
+            assert isinstance(p.transformer, transformer.Transformer)
+            assert p.transformer.script_file == p_json["transformer"]
+            assert isinstance(p.transformer.resources, resources.TransformerResources)
+            assert isinstance(p.inference_logger, inference_logger.InferenceLogger)
+            assert p.inference_logger.mode == p_json["inference_logging"]
+            assert isinstance(p.inference_batcher, inference_batcher.InferenceBatcher)
+            assert p.inference_batcher.enabled == bool(
+                p_json["batching_configuration"]["batching_enabled"]
+            )
+
+    def test_from_response_json_single(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        p_json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+            "items"
+        ][0]
+
+        # Act
+        p = predictor.Predictor.from_response_json(p_json)
+
+        # Assert
+        assert isinstance(p, predictor.Predictor)
+        assert p.id == p_json["id"]
+        assert p.name == p_json["name"]
+        assert p.description == p_json["description"]
+        assert p.created_at == p_json["created"]
+        assert p.creator == p_json["creator"]
+        assert p.model_path == p_json["model_path"]
+        assert p.model_version == p_json["model_version"]
+        assert p.model_name == p_json["model_name"]
+        assert p.model_framework == p_json["model_framework"]
+        assert p.model_server == p_json["model_server"]
+        assert p.serving_tool == p_json["serving_tool"]
+        assert p.api_protocol == p_json["api_protocol"]
+        assert p.artifact_version == p_json["artifact_version"]
+        assert p.script_file == p_json["predictor"]
+        assert isinstance(p.resources, resources.PredictorResources)
+        assert isinstance(p.transformer, transformer.Transformer)
+        assert p.transformer.script_file == p_json["transformer"]
+        assert isinstance(p.transformer.resources, resources.TransformerResources)
+        assert isinstance(p.inference_logger, inference_logger.InferenceLogger)
+        assert p.inference_logger.mode == p_json["inference_logging"]
+        assert isinstance(p.inference_batcher, inference_batcher.InferenceBatcher)
+        assert p.inference_batcher.enabled == bool(
+            p_json["batching_configuration"]["batching_enabled"]
+        )
+
+    # constructor
+
+    def test_constructor(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        p_json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+            "items"
+        ][0]
+        mock_validate_serving_tool = mocker.patch(
+            "hsml.predictor.Predictor._validate_serving_tool",
+            return_value=p_json["serving_tool"],
+        )
+        mock_resources = util.get_obj_from_json(
+            copy.deepcopy(p_json["predictor_resources"]), resources.PredictorResources
+        )
+        mock_validate_resources = mocker.patch(
+            "hsml.predictor.Predictor._validate_resources",
+            return_value=mock_resources,
+        )
+        mock_validate_script_file = mocker.patch(
+            "hsml.predictor.Predictor._validate_script_file",
+            return_value=p_json["predictor"],
+        )
+
+        # Act
+        p = predictor.Predictor(
+            id=p_json["id"],
+            name=p_json["name"],
+            description=p_json["description"],
+            created_at=p_json["created"],
+            creator=p_json["creator"],
+            model_path=p_json["model_path"],
+            model_version=p_json["model_version"],
+            model_name=p_json["model_name"],
+            model_framework=p_json["model_framework"],
+            model_server=p_json["model_server"],
+            serving_tool=p_json["serving_tool"],
+            api_protocol=p_json["api_protocol"],
+            artifact_version=p_json["artifact_version"],
+            script_file=p_json["predictor"],
+            resources=p_json["predictor_resources"],
+            transformer={
+                "script_file": p_json["transformer"],
+                "resources": copy.deepcopy(p_json["transformer_resources"]),
+            },
+            inference_logger={
+                "mode": p_json["inference_logging"],
+                "kafka_topic": copy.deepcopy(p_json["kafka_topic_dto"]),
+            },
+            inference_batcher=copy.deepcopy(p_json["batching_configuration"]),
+        )
+
+        # Assert
+        assert p.id == p_json["id"]
+        assert p.name == p_json["name"]
+        assert p.description == p_json["description"]
+        assert p.created_at == p_json["created"]
+        assert p.creator == p_json["creator"]
+        assert p.model_path == p_json["model_path"]
+        assert p.model_name == p_json["model_name"]
+        assert p.model_version == p_json["model_version"]
+        assert p.model_framework == p_json["model_framework"]
+        assert p.model_server == p_json["model_server"]
+        assert p.serving_tool == p_json["serving_tool"]
+        assert p.api_protocol == p_json["api_protocol"]
+        assert p.artifact_version == p_json["artifact_version"]
+        assert p.script_file == p_json["predictor"]
+        assert isinstance(p.resources, resources.PredictorResources)
+        assert isinstance(p.transformer, transformer.Transformer)
+        assert p.transformer.script_file == p_json["transformer"]
+        assert isinstance(p.transformer.resources, resources.TransformerResources)
+        assert isinstance(p.inference_logger, inference_logger.InferenceLogger)
+        assert p.inference_logger.mode == p_json["inference_logging"]
+        assert isinstance(p.inference_batcher, inference_batcher.InferenceBatcher)
+        assert p.inference_batcher.enabled == bool(
+            p_json["batching_configuration"]["batching_enabled"]
+        )
+        mock_validate_serving_tool.assert_called_once_with(p_json["serving_tool"])
+        assert mock_validate_resources.call_count == 1
+        mock_validate_script_file.assert_called_once_with(
+            p_json["model_framework"], p_json["predictor"]
+        )
+
+    # validate serving tool
+
+    def test_validate_serving_tool_none(self):
+        # Act
+        st = predictor.Predictor._validate_serving_tool(None)
+
+        # Assert
+        assert st is None
+
+    def test_validate_serving_tool_valid(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, is_saas_connection=False
+        )
+
+        # Act
+        st = predictor.Predictor._validate_serving_tool(PREDICTOR.SERVING_TOOL_DEFAULT)
+
+        # Assert
+        assert st == PREDICTOR.SERVING_TOOL_DEFAULT
+
+    def test_validate_serving_tool_invalid(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, is_saas_connection=False
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = predictor.Predictor._validate_serving_tool("INVALID_NAME")
+
+        # Assert
+        assert "is not valid" in str(e_info.value)
+
+    def test_validate_serving_tool_valid_saas_connection(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, is_saas_connection=True
+        )
+
+        # Act
+        st = predictor.Predictor._validate_serving_tool(PREDICTOR.SERVING_TOOL_KSERVE)
+
+        # Assert
+        assert st == PREDICTOR.SERVING_TOOL_KSERVE
+
+    def test_validate_serving_tool_invalid_saas_connection(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, is_saas_connection=True
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = predictor.Predictor._validate_serving_tool(
+                PREDICTOR.SERVING_TOOL_DEFAULT
+            )
+
+        # Assert
+        assert "KServe deployments are the only supported" in str(e_info.value)
+
+    # validate script file
+
+    def test_validate_script_file_tf_none(self):
+        # Act
+        predictor.Predictor._validate_script_file(MODEL.FRAMEWORK_TENSORFLOW, None)
+
+    def test_validate_script_file_sk_none(self):
+        # Act
+        predictor.Predictor._validate_script_file(MODEL.FRAMEWORK_SKLEARN, None)
+
+    def test_validate_script_file_th_none(self):
+        # Act
+        predictor.Predictor._validate_script_file(MODEL.FRAMEWORK_TORCH, None)
+
+    def test_validate_script_file_py_none(self):
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = predictor.Predictor._validate_script_file(MODEL.FRAMEWORK_PYTHON, None)
+
+        # Assert
+        assert "Predictor scripts are required" in str(e_info.value)
+
+    def test_validate_script_file_tf_script_file(self):
+        # Act
+        predictor.Predictor._validate_script_file(
+            MODEL.FRAMEWORK_TENSORFLOW, "script_file"
+        )
+
+    def test_validate_script_file_sk_script_file(self):
+        # Act
+        predictor.Predictor._validate_script_file(
+            MODEL.FRAMEWORK_SKLEARN, "script_file"
+        )
+
+    def test_validate_script_file_th_script_file(self):
+        # Act
+        predictor.Predictor._validate_script_file(MODEL.FRAMEWORK_TORCH, "script_file")
+
+    def test_validate_script_file_py_script_file(self):
+        # Act
+        predictor.Predictor._validate_script_file(MODEL.FRAMEWORK_PYTHON, "script_file")
+
+    # infer model server
+
+    def test_infer_model_server_tf(self):
+        # Act
+        ms = predictor.Predictor._infer_model_server(MODEL.FRAMEWORK_TENSORFLOW)
+
+        # Assert
+        assert ms == PREDICTOR.MODEL_SERVER_TF_SERVING
+
+    def test_infer_model_server_sk(self):
+        # Act
+        ms = predictor.Predictor._infer_model_server(MODEL.FRAMEWORK_SKLEARN)
+
+        # Assert
+        assert ms == PREDICTOR.MODEL_SERVER_PYTHON
+
+    def test_infer_model_server_th(self):
+        # Act
+        ms = predictor.Predictor._infer_model_server(MODEL.FRAMEWORK_TORCH)
+
+        # Assert
+        assert ms == PREDICTOR.MODEL_SERVER_PYTHON
+
+    def test_infer_model_server_py(self):
+        # Act
+        ms = predictor.Predictor._infer_model_server(MODEL.FRAMEWORK_PYTHON)
+
+        # Assert
+        assert ms == PREDICTOR.MODEL_SERVER_PYTHON
+
+    # default serving tool
+
+    def test_get_default_serving_tool_kserve_installed(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, is_kserve_installed=True
+        )
+
+        # Act
+        st = predictor.Predictor._get_default_serving_tool()
+
+        # Assert
+        assert st == PREDICTOR.SERVING_TOOL_KSERVE
+
+    def test_get_default_serving_tool_kserve_not_installed(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, is_kserve_installed=False
+        )
+
+        # Act
+        st = predictor.Predictor._get_default_serving_tool()
+
+        # Assert
+        assert st == PREDICTOR.SERVING_TOOL_DEFAULT
+
+    # validate resources
+
+    def test_validate_resources_none_non_kserve(self):
+        # Act
+        res = predictor.Predictor._validate_resources(
+            None, PREDICTOR.SERVING_TOOL_DEFAULT
+        )
+
+        # Assert
+        assert res is None
+
+    def test_validate_resources_none_kserve(self):
+        # Act
+        res = predictor.Predictor._validate_resources(
+            None, PREDICTOR.SERVING_TOOL_KSERVE
+        )
+
+        # Assert
+        assert res is None
+
+    def test_validate_resources_num_instances_zero_non_kserve(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        pr = resources.PredictorResources(num_instances=0)
+
+        # Act
+        res = predictor.Predictor._validate_resources(
+            pr, PREDICTOR.SERVING_TOOL_DEFAULT
+        )
+
+        # Assert
+        assert res == pr
+
+    def test_validate_resources_num_instances_zero_kserve(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        pr = resources.PredictorResources(num_instances=0)
+
+        # Act
+        res = predictor.Predictor._validate_resources(pr, PREDICTOR.SERVING_TOOL_KSERVE)
+
+        # Assert
+        assert res == pr
+
+    def test_validate_resources_num_instances_one_without_scale_to_zero_non_kserve(
+        self, mocker
+    ):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        pr = resources.PredictorResources(num_instances=1)
+
+        # Act
+        res = predictor.Predictor._validate_resources(
+            pr, PREDICTOR.SERVING_TOOL_DEFAULT
+        )
+
+        # Assert
+        assert res == pr
+
+    def test_validate_resources_num_instances_one_without_scale_to_zero_kserve(
+        self, mocker
+    ):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        pr = resources.PredictorResources(num_instances=1)
+
+        # Act
+        res = predictor.Predictor._validate_resources(pr, PREDICTOR.SERVING_TOOL_KSERVE)
+
+        # Assert
+        assert res == pr
+
+    def test_validate_resources_num_instances_one_with_scale_to_zero_non_kserve(
+        self, mocker
+    ):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+        pr = resources.PredictorResources(num_instances=1)
+
+        # Act
+        res = predictor.Predictor._validate_resources(
+            pr, PREDICTOR.SERVING_TOOL_DEFAULT
+        )
+
+        # Assert
+        assert res == pr
+
+    def test_validate_resources_num_instances_one_with_scale_to_zero_kserve(
+        self, mocker
+    ):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+        pr = resources.PredictorResources(num_instances=1)
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = predictor.Predictor._validate_resources(
+                pr, PREDICTOR.SERVING_TOOL_KSERVE
+            )
+
+        # Assert
+        assert "Scale-to-zero is required" in str(e_info.value)
+
+    # default resources
+
+    def test_get_default_resources_non_kserve_without_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+
+        # Act
+        res = predictor.Predictor._get_default_resources(PREDICTOR.SERVING_TOOL_DEFAULT)
+
+        # Assert
+        assert isinstance(res, resources.PredictorResources)
+        assert res.num_instances == RESOURCES.MIN_NUM_INSTANCES
+
+    def test_get_default_resources_non_kserve_with_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        res = predictor.Predictor._get_default_resources(PREDICTOR.SERVING_TOOL_DEFAULT)
+
+        # Assert
+        assert isinstance(res, resources.PredictorResources)
+        assert res.num_instances == RESOURCES.MIN_NUM_INSTANCES
+
+    def test_get_default_resources_kserve_without_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+
+        # Act
+        res = predictor.Predictor._get_default_resources(PREDICTOR.SERVING_TOOL_KSERVE)
+
+        # Assert
+        assert isinstance(res, resources.PredictorResources)
+        assert res.num_instances == RESOURCES.MIN_NUM_INSTANCES
+
+    def test_get_default_resources_kserve_with_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        res = predictor.Predictor._get_default_resources(PREDICTOR.SERVING_TOOL_KSERVE)
+
+        # Assert
+        assert isinstance(res, resources.PredictorResources)
+        assert res.num_instances == 0
+
+    # for model
+
+    def test_for_model(self, mocker):
+        # Arrange
+        def spec(model, model_name, model_version, model_path):
+            pass
+
+        mock_get_predictor_for_model = mocker.patch(
+            "hsml.util.get_predictor_for_model", return_value=True, spec=spec
+        )
+
+        class MockModel:
+            name = "model_name"
+            version = "model_version"
+            model_path = "model_path"
+
+        mock_model = MockModel()
+
+        # Act
+        predictor.Predictor.for_model(mock_model)
+
+        # Assert
+        mock_get_predictor_for_model.assert_called_once_with(
+            model=mock_model,
+            model_name=mock_model.name,
+            model_version=mock_model.version,
+            model_path=mock_model.model_path,
+        )
+
+    # extract fields from json
+
+    def extract_fields_from_json(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        p_json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+            "items"
+        ][0]
+
+        # Act
+        kwargs = predictor.Predictor.extract_fields_from_json(p_json)
+
+        # Assert
+        assert kwargs["id"] == p_json["id"]
+        assert kwargs["name"] == p_json["name"]
+        assert kwargs["description"] == p_json["description"]
+        assert kwargs["created_at"] == p_json["created"]
+        assert kwargs["creator"] == p_json["creator"]
+        assert kwargs["model_name"] == p_json["model_name"]
+        assert kwargs["model_path"] == p_json["model_path"]
+        assert kwargs["model_version"] == p_json["model_version"]
+        assert kwargs["model_framework"] == p_json["model_framework"]
+        assert kwargs["artifact_version"] == p_json["artifact_version"]
+        assert kwargs["model_server"] == p_json["model_server"]
+        assert kwargs["serving_tool"] == p_json["serving_tool"]
+        assert kwargs["script_file"] == p_json["predictor"]
+        assert isinstance(kwargs["resources"], resources.PredictorResources)
+        assert isinstance(kwargs["inference_logger"], inference_logger.InferenceLogger)
+        assert kwargs["inference_logger"].mode == p_json["inference_logging"]
+        assert isinstance(
+            kwargs["inference_batcher"], inference_batcher.InferenceBatcher
+        )
+        assert kwargs["inference_batcher"].enabled == bool(
+            p_json["batching_configuration"]["batching_enabled"]
+        )
+        assert kwargs["api_protocol"] == p_json["api_protocol"]
+        assert isinstance(kwargs["transformer"], transformer.Transformer)
+        assert kwargs["transformer"].script_file == p_json["transformer"]
+        assert isinstance(
+            kwargs["transformer"].resources, resources.TransformerResources
+        )
+
+    # deploy
+
+    def test_deploy(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        p_json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+            "items"
+        ][0]
+        mock_deployment_init = mocker.patch(
+            "hsml.deployment.Deployment.__init__", return_value=None
+        )
+        mock_deployment_save = mocker.patch("hsml.deployment.Deployment.save")
+
+        # Act
+
+        p = predictor.Predictor.from_response_json(p_json)
+        p.deploy()
+
+        # Assert
+        mock_deployment_init.assert_called_once_with(
+            predictor=p,
+            name=p.name,
+            description=p.description,
+        )
+        mock_deployment_save.assert_called_once()
+
+    # auxiliary methods
+
+    def _mock_serving_variables(
+        self,
+        mocker,
+        num_instances,
+        force_scale_to_zero=False,
+        is_saas_connection=False,
+        is_kserve_installed=True,
+    ):
+        mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=SERVING_RESOURCE_LIMITS,
+        )
+        mocker.patch(
+            "hsml.client.get_serving_num_instances_limits", return_value=num_instances
+        )
+        mocker.patch(
+            "hsml.client.is_scale_to_zero_required", return_value=force_scale_to_zero
+        )
+        mocker.patch("hsml.client.is_saas_connection", return_value=is_saas_connection)
+        mocker.patch(
+            "hsml.client.is_kserve_installed", return_value=is_kserve_installed
+        )

--- a/python/tests/test_predictor_state.py
+++ b/python/tests/test_predictor_state.py
@@ -14,14 +14,13 @@
 #   limitations under the License.
 #
 
-import humps
 import copy
 
+import humps
 from hsml import predictor_state, predictor_state_condition
 
 
 class TestPredictorState:
-
     # from response json
 
     def test_from_response_json(self, backend_fixtures):

--- a/python/tests/test_predictor_state.py
+++ b/python/tests/test_predictor_state.py
@@ -1,0 +1,127 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import humps
+import copy
+
+from hsml import predictor_state, predictor_state_condition
+
+
+class TestPredictorState:
+
+    # from response json
+
+    def test_from_response_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_predictor_state"][
+            "response"
+        ]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+
+        # Act
+        ps = predictor_state.PredictorState.from_response_json(json_camelized)
+
+        # Assert
+        assert isinstance(ps, predictor_state.PredictorState)
+        assert ps.available_predictor_instances == json["available_instances"]
+        assert (
+            ps.available_transformer_instances
+            == json["available_transformer_instances"]
+        )
+        assert ps.hopsworks_inference_path == json["hopsworks_inference_path"]
+        assert ps.model_server_inference_path == json["model_server_inference_path"]
+        assert ps.internal_port == json["internal_port"]
+        assert ps.revision == json["revision"]
+        assert ps.deployed == json["deployed"]
+        assert isinstance(
+            ps.condition, predictor_state_condition.PredictorStateCondition
+        )
+        assert ps.condition.status == json["condition"]["status"]
+        assert ps.status == json["status"]
+
+    # constructor
+
+    def test_constructor(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_predictor_state"][
+            "response"
+        ]
+
+        # Act
+        ps = predictor_state.PredictorState(
+            available_predictor_instances=json["available_instances"],
+            available_transformer_instances=json["available_transformer_instances"],
+            hopsworks_inference_path=json["hopsworks_inference_path"],
+            model_server_inference_path=json["model_server_inference_path"],
+            internal_port=json["internal_port"],
+            revision=json["revision"],
+            deployed=json["deployed"],
+            condition=predictor_state_condition.PredictorStateCondition(
+                **copy.deepcopy(json["condition"])
+            ),
+            status=json["status"],
+        )
+
+        # Assert
+        assert isinstance(ps, predictor_state.PredictorState)
+        assert ps.available_predictor_instances == json["available_instances"]
+        assert (
+            ps.available_transformer_instances
+            == json["available_transformer_instances"]
+        )
+        assert ps.hopsworks_inference_path == json["hopsworks_inference_path"]
+        assert ps.model_server_inference_path == json["model_server_inference_path"]
+        assert ps.internal_port == json["internal_port"]
+        assert ps.revision == json["revision"]
+        assert ps.deployed == json["deployed"]
+        assert isinstance(
+            ps.condition, predictor_state_condition.PredictorStateCondition
+        )
+        assert ps.condition.status == json["condition"]["status"]
+        assert ps.status == json["status"]
+
+    # extract fields from json
+
+    def test_extract_fields_from_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_predictor_state"][
+            "response"
+        ]
+
+        # Act
+        (
+            ai,
+            ati,
+            hip,
+            msip,
+            ipt,
+            r,
+            d,
+            c,
+            s,
+        ) = predictor_state.PredictorState.extract_fields_from_json(copy.deepcopy(json))
+
+        # Assert
+        assert ai == json["available_instances"]
+        assert ati == json["available_transformer_instances"]
+        assert hip == json["hopsworks_inference_path"]
+        assert msip == json["model_server_inference_path"]
+        assert ipt == json["internal_port"]
+        assert r == json["revision"]
+        assert d == json["deployed"]
+        assert isinstance(c, predictor_state_condition.PredictorStateCondition)
+        assert c.status == json["condition"]["status"]
+        assert s == json["status"]

--- a/python/tests/test_predictor_state_condition.py
+++ b/python/tests/test_predictor_state_condition.py
@@ -14,14 +14,13 @@
 #   limitations under the License.
 #
 
-import humps
 import copy
 
+import humps
 from hsml import predictor_state_condition
 
 
 class TestPredictorStateCondition:
-
     # from response json
 
     def test_from_response_json(self, backend_fixtures):
@@ -70,15 +69,13 @@ class TestPredictorStateCondition:
         ]["condition"]
 
         # Act
-        (
-            t,
-            s,
-            r,
-        ) = predictor_state_condition.PredictorStateCondition.extract_fields_from_json(
-            copy.deepcopy(json)
+        kwargs = (
+            predictor_state_condition.PredictorStateCondition.extract_fields_from_json(
+                copy.deepcopy(json)
+            )
         )
 
         # Assert
-        assert t == json["type"]
-        assert s == json["status"]
-        assert r == json["reason"]
+        assert kwargs["type"] == json["type"]
+        assert kwargs["status"] == json["status"]
+        assert kwargs["reason"] == json["reason"]

--- a/python/tests/test_predictor_state_condition.py
+++ b/python/tests/test_predictor_state_condition.py
@@ -1,0 +1,84 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import humps
+import copy
+
+from hsml import predictor_state_condition
+
+
+class TestPredictorStateCondition:
+
+    # from response json
+
+    def test_from_response_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_predictor_state"][
+            "response"
+        ]["condition"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+
+        # Act
+        psc = predictor_state_condition.PredictorStateCondition.from_response_json(
+            json_camelized
+        )
+
+        # Assert
+        assert isinstance(psc, predictor_state_condition.PredictorStateCondition)
+        assert psc.type == json["type"]
+        assert psc.status == json["status"]
+        assert psc.reason == json["reason"]
+
+    # constructor
+
+    def test_constructor(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_predictor_state"][
+            "response"
+        ]["condition"]
+
+        # Act
+        psc = predictor_state_condition.PredictorStateCondition(
+            type=json["type"], status=json["status"], reason=json["reason"]
+        )
+
+        # Assert
+        assert isinstance(psc, predictor_state_condition.PredictorStateCondition)
+        assert psc.type == json["type"]
+        assert psc.status == json["status"]
+        assert psc.reason == json["reason"]
+
+    # extract fields from json
+
+    def test_extract_fields_from_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["predictor"]["get_deployment_predictor_state"][
+            "response"
+        ]["condition"]
+
+        # Act
+        (
+            t,
+            s,
+            r,
+        ) = predictor_state_condition.PredictorStateCondition.extract_fields_from_json(
+            copy.deepcopy(json)
+        )
+
+        # Assert
+        assert t == json["type"]
+        assert s == json["status"]
+        assert r == json["reason"]

--- a/python/tests/test_resources.py
+++ b/python/tests/test_resources.py
@@ -1,0 +1,845 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import copy
+
+from hsml import resources
+from hsml.constants import RESOURCES
+
+SERVING_RESOURCE_LIMITS = {"cores": 2, "memory": 516, "gpus": 2}
+
+
+class TestResources:
+
+    # Resources
+
+    def test_from_response_json_cpus(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"]["get_only_cores"]["response"]
+
+        # Act
+        r = resources.Resources.from_response_json(json)
+
+        # Assert
+        assert r.cores == json["cores"]
+        assert r.memory is None
+        assert r.gpus is None
+
+    def test_from_response_json_memory(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"]["get_only_memory"]["response"]
+
+        # Act
+        r = resources.Resources.from_response_json(json)
+
+        # Assert
+        assert r.cores is None
+        assert r.memory is json["memory"]
+        assert r.gpus is None
+
+    def test_from_response_json_gpus(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"]["get_only_gpus"]["response"]
+
+        # Act
+        r = resources.Resources.from_response_json(json)
+
+        # Assert
+        assert r.cores is None
+        assert r.memory is None
+        assert r.gpus == json["gpus"]
+
+    def test_from_response_json_cores_and_memory(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"]["get_cores_and_memory"]["response"]
+
+        # Act
+        r = resources.Resources.from_response_json(json)
+
+        # Assert
+        assert r.cores == json["cores"]
+        assert r.memory == json["memory"]
+        assert r.gpus is None
+
+    def test_from_response_json_cores_and_gpus(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"]["get_cores_and_gpus"]["response"]
+
+        # Act
+        r = resources.Resources.from_response_json(json)
+
+        # Assert
+        assert r.cores == json["cores"]
+        assert r.memory is None
+        assert r.gpus == json["gpus"]
+
+    def test_from_response_json_memory_and_gpus(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"]["get_memory_and_gpus"]["response"]
+
+        # Act
+        r = resources.Resources.from_response_json(json)
+
+        # Assert
+        assert r.cores is None
+        assert r.memory == json["memory"]
+        assert r.gpus == json["gpus"]
+
+    def test_from_response_json_cores_memory_and_gpus(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"]["get_cores_memory_and_gpus"]["response"]
+
+        # Act
+        r = resources.Resources.from_response_json(json)
+
+        # Assert
+        assert r.cores == json["cores"]
+        assert r.memory == json["memory"]
+        assert r.gpus == json["gpus"]
+
+    # ComponentResources
+
+    # - from response json
+
+    def test_from_response_json_component_resources(self, mocker):
+        # Arrange
+        res = {"something": "here"}
+        json_decamelized = {"key": "value"}
+        mock_humps_decamelize = mocker.patch(
+            "humps.decamelize", return_value=json_decamelized
+        )
+        mock_from_json = mocker.patch(
+            "hsml.resources.ComponentResources.from_json",
+            return_value="from_json_result",
+        )
+
+        # Act
+        result = resources.ComponentResources.from_response_json(res)
+
+        # Assert
+        assert result == "from_json_result"
+        mock_humps_decamelize.assert_called_once_with(res)
+        mock_from_json.assert_called_once_with(json_decamelized)
+
+    # - constructor
+
+    def test_constructor_component_resources_default(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"][
+            "get_component_resources_num_instances_requests_and_limits"
+        ]["response"]
+        mock_default_resource_limits = mocker.patch(
+            "hsml.resources.ComponentResources._get_default_resource_limits",
+            return_value="limits",
+        )
+        mock_validate_resources = mocker.patch(
+            "hsml.resources.ComponentResources._validate_resources"
+        )
+        mock_resources_init = mocker.patch(
+            "hsml.resources.Resources.__init__", return_value=None
+        )
+
+        # Act
+        pr = resources.PredictorResources(num_instances=json["num_instances"])
+
+        # Assert
+        assert pr.num_instances == json["num_instances"]
+        mock_default_resource_limits.assert_called_once()
+        mock_validate_resources.assert_called_once_with(pr._requests, pr._limits)
+        mock_resources_init.assert_called_once_with(
+            RESOURCES.MIN_CORES, RESOURCES.MIN_MEMORY, RESOURCES.MIN_GPUS
+        )
+
+    def test_constructor_component_resources(self, mocker, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["resources"][
+            "get_component_resources_num_instances_requests_and_limits"
+        ]["response"]
+        mock_util_get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json",
+            side_effect=[json["requests"], json["limits"]],
+        )
+        mock_default_resource_limits = mocker.patch(
+            "hsml.resources.ComponentResources._get_default_resource_limits",
+            return_value="limits",
+        )
+        mock_validate_resources = mocker.patch(
+            "hsml.resources.ComponentResources._validate_resources"
+        )
+
+        # Act
+        pr = resources.PredictorResources(
+            num_instances=json["num_instances"],
+            requests=json["requests"],
+            limits=json["limits"],
+        )
+
+        # Assert
+        assert pr.num_instances == json["num_instances"]
+        assert pr.requests == json["requests"]
+        assert pr.limits == json["limits"]
+        mock_default_resource_limits.assert_not_called()
+        mock_validate_resources.assert_called_once_with(pr._requests, pr._limits)
+        mock_util_get_obj_from_json.call_count == 2
+
+    # - extract fields from json
+
+    def test_extract_fields_from_json_component_resources_with_key(
+        self, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["resources"][
+            "get_component_resources_requested_instances_and_predictor_resources"
+        ]["response"]
+        copy_json = copy.deepcopy(json)
+        resources.ComponentResources.RESOURCES_CONFIG_KEY = "predictor_resources"
+        resources.ComponentResources.NUM_INSTANCES_KEY = "requested_instances"
+
+        # Act
+        kwargs = resources.ComponentResources.extract_fields_from_json(copy_json)
+
+        # Assert
+        assert kwargs["num_instances"] == json["requested_instances"]
+        assert isinstance(kwargs["requests"], resources.Resources)
+        assert (
+            kwargs["requests"].cores == json["predictor_resources"]["requests"]["cores"]
+        )
+        assert (
+            kwargs["requests"].memory
+            == json["predictor_resources"]["requests"]["memory"]
+        )
+        assert (
+            kwargs["requests"].gpus == json["predictor_resources"]["requests"]["gpus"]
+        )
+        assert isinstance(kwargs["limits"], resources.Resources)
+        assert kwargs["limits"].cores == json["predictor_resources"]["limits"]["cores"]
+        assert (
+            kwargs["limits"].memory == json["predictor_resources"]["limits"]["memory"]
+        )
+        assert kwargs["limits"].gpus == json["predictor_resources"]["limits"]["gpus"]
+
+    def test_extract_fields_from_json_component_resources(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["resources"][
+            "get_component_resources_requested_instances_and_predictor_resources_alternative"
+        ]["response"]
+        copy_json = copy.deepcopy(json)
+        resources.ComponentResources.RESOURCES_CONFIG_KEY = "predictor_resources"
+        resources.ComponentResources.NUM_INSTANCES_KEY = "requested_instances"
+
+        # Act
+        kwargs = resources.ComponentResources.extract_fields_from_json(copy_json)
+
+        # Assert
+        assert kwargs["num_instances"] == json["num_instances"]
+        assert isinstance(kwargs["requests"], resources.Resources)
+        assert kwargs["requests"].cores == json["resources"]["requests"]["cores"]
+        assert kwargs["requests"].memory == json["resources"]["requests"]["memory"]
+        assert kwargs["requests"].gpus == json["resources"]["requests"]["gpus"]
+        assert isinstance(kwargs["limits"], resources.Resources)
+        assert kwargs["limits"].cores == json["resources"]["limits"]["cores"]
+        assert kwargs["limits"].memory == json["resources"]["limits"]["memory"]
+        assert kwargs["limits"].gpus == json["resources"]["limits"]["gpus"]
+
+    def test_extract_fields_from_json_component_resources_flatten(
+        self, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["resources"][
+            "get_component_resources_num_instances_requests_and_limits"
+        ]["response"]
+        copy_json = copy.deepcopy(json)
+        resources.ComponentResources.RESOURCES_CONFIG_KEY = "predictor_resources"
+        resources.ComponentResources.NUM_INSTANCES_KEY = "requested_instances"
+
+        # Act
+        kwargs = resources.ComponentResources.extract_fields_from_json(copy_json)
+
+        # Assert
+        assert kwargs["num_instances"] == json["num_instances"]
+        assert isinstance(kwargs["requests"], resources.Resources)
+        assert kwargs["requests"].cores == json["requests"]["cores"]
+        assert kwargs["requests"].memory == json["requests"]["memory"]
+        assert kwargs["requests"].gpus == json["requests"]["gpus"]
+        assert isinstance(kwargs["limits"], resources.Resources)
+        assert kwargs["limits"].cores == json["limits"]["cores"]
+        assert kwargs["limits"].memory == json["limits"]["memory"]
+        assert kwargs["limits"].gpus == json["limits"]["gpus"]
+
+    # - get default resource limits
+
+    def test_get_default_resource_limits_no_hard_limit_and_lower_than_default(
+        self, mocker
+    ):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        mock_comp_res = mocker.MagicMock()
+        mock_comp_res._requests = resources.Resources(cores=0.2, memory=516, gpus=0)
+        mock_comp_res._default_resource_limits = (
+            resources.ComponentResources._get_default_resource_limits
+        )
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # no upper limit
+        )
+
+        # Act
+        res = mock_comp_res._default_resource_limits(mock_comp_res)
+
+        # Assert
+        assert isinstance(res, resources.Resources)
+        assert res.cores == RESOURCES.MAX_CORES
+        assert res.memory == RESOURCES.MAX_MEMORY
+        assert res.gpus == RESOURCES.MAX_GPUS
+        mock_get_serving_res_limits.assert_called_once()
+
+    def test_get_default_resource_limits_no_hard_limit_and_higher_than_default(
+        self, mocker
+    ):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        mock_comp_res = mocker.MagicMock()
+        mock_comp_res._requests = resources.Resources(cores=4, memory=2048, gpus=2)
+        mock_comp_res._default_resource_limits = (
+            resources.ComponentResources._get_default_resource_limits
+        )
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # no upper limit
+        )
+
+        # Act
+        res = mock_comp_res._default_resource_limits(mock_comp_res)
+
+        # Assert
+        assert isinstance(res, resources.Resources)
+        assert res.cores == mock_comp_res._requests.cores
+        assert res.memory == mock_comp_res._requests.memory
+        assert res.gpus == mock_comp_res._requests.gpus
+        mock_get_serving_res_limits.assert_called_once()
+
+    def test_get_default_resource_limits_with_higher_hard_limit_and_lower_than_default(
+        self, mocker
+    ):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        mock_comp_res = mocker.MagicMock()
+        mock_comp_res._requests = resources.Resources(cores=1, memory=516, gpus=0)
+        mock_comp_res._default_resource_limits = (
+            resources.ComponentResources._get_default_resource_limits
+        )
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        res = mock_comp_res._default_resource_limits(mock_comp_res)
+
+        # Assert
+        assert isinstance(res, resources.Resources)
+        assert res.cores == RESOURCES.MAX_CORES
+        assert res.memory == RESOURCES.MAX_MEMORY
+        assert res.gpus == RESOURCES.MAX_GPUS
+        mock_get_serving_res_limits.assert_called_once()
+
+    def test_get_default_resource_limits_with_higher_hard_limit_and_higher_than_default(
+        self, mocker
+    ):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        mock_comp_res = mocker.MagicMock()
+        mock_comp_res._requests = resources.Resources(cores=3, memory=2048, gpus=1)
+        mock_comp_res._default_resource_limits = (
+            resources.ComponentResources._get_default_resource_limits
+        )
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        res = mock_comp_res._default_resource_limits(mock_comp_res)
+
+        # Assert
+        assert isinstance(res, resources.Resources)
+        assert res.cores == hard_limit_res["cores"]
+        assert res.memory == hard_limit_res["memory"]
+        assert res.gpus == hard_limit_res["gpus"]
+        mock_get_serving_res_limits.assert_called_once()
+
+    def test_get_default_resource_limits_with_lower_hard_limit_and_lower_than_default(
+        self, mocker
+    ):
+        # Arrange
+        RESOURCES.MAX_GPUS = 1  # override default
+        hard_limit_res = {"cores": 1, "memory": 516, "gpus": 0}
+        mock_comp_res = mocker.MagicMock()
+        mock_comp_res._requests = resources.Resources(cores=0.5, memory=256, gpus=0.5)
+        mock_comp_res._default_resource_limits = (
+            resources.ComponentResources._get_default_resource_limits
+        )
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        res = mock_comp_res._default_resource_limits(mock_comp_res)
+
+        # Assert
+        assert isinstance(res, resources.Resources)
+        assert res.cores == hard_limit_res["cores"]
+        assert res.memory == hard_limit_res["memory"]
+        assert res.gpus == hard_limit_res["gpus"]
+        mock_get_serving_res_limits.assert_called_once()
+
+    def test_get_default_resource_limits_with_lower_hard_limit_and_higher_than_default(
+        self, mocker
+    ):
+        # Arrange
+        RESOURCES.MAX_GPUS = 1  # override default
+        hard_limit_res = {"cores": 1, "memory": 516, "gpus": 0}
+        mock_comp_res = mocker.MagicMock()
+        mock_comp_res._requests = resources.Resources(cores=4, memory=4080, gpus=4)
+        mock_comp_res._default_resource_limits = (
+            resources.ComponentResources._get_default_resource_limits
+        )
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        res = mock_comp_res._default_resource_limits(mock_comp_res)
+
+        # Assert
+        assert isinstance(res, resources.Resources)
+        assert res.cores == hard_limit_res["cores"]
+        assert res.memory == hard_limit_res["memory"]
+        assert res.gpus == hard_limit_res["gpus"]
+        mock_get_serving_res_limits.assert_called_once()
+
+    # - validate resources
+
+    def test_validate_resources_no_hard_limits_valid_resources(self, mocker):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        requests = resources.Resources(cores=1, memory=1024, gpus=0)
+        limits = resources.Resources(cores=2, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # upper limit
+        )
+
+        # Act
+        resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+
+    def test_validate_resources_no_hard_limit_invalid_cores_request(self, mocker):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        requests = resources.Resources(cores=0, memory=1024, gpus=0)
+        limits = resources.Resources(cores=2, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert "Requested number of cores must be greater than 0 cores." in str(
+            e_info.value
+        )
+
+    def test_validate_resources_no_hard_limit_invalid_memory_request(self, mocker):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        requests = resources.Resources(cores=1, memory=0, gpus=0)
+        limits = resources.Resources(cores=2, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert "Requested memory resources must be greater than 0 MB." in str(
+            e_info.value
+        )
+
+    def test_validate_resources_no_hard_limit_invalid_gpus_request(self, mocker):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        requests = resources.Resources(
+            cores=1, memory=1024, gpus=-1
+        )  # 0 gpus is accepted
+        limits = resources.Resources(cores=2, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert (
+            "Requested number of gpus must be greater than or equal to 0 gpus."
+            in str(e_info.value)
+        )
+
+    def test_validate_resources_no_hard_limit_cores_request_out_of_range(self, mocker):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        requests = resources.Resources(cores=2, memory=1024, gpus=0)
+        limits = resources.Resources(cores=1, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert (
+            f"Requested number of cores cannot exceed the limit of {str(limits.cores)} cores."
+            in str(e_info.value)
+        )
+
+    def test_validate_resources_no_hard_limit_invalid_memory_request_out_of_range(
+        self, mocker
+    ):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        requests = resources.Resources(cores=1, memory=2048, gpus=0)
+        limits = resources.Resources(cores=2, memory=1024, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert (
+            f"Requested memory resources cannot exceed the limit of {str(limits.memory)} MB."
+            in str(e_info.value)
+        )
+
+    def test_validate_resources_no_hard_limit_invalid_gpus_request_out_of_range(
+        self, mocker
+    ):
+        # Arrange
+        no_limit_res = {"cores": -1, "memory": -1, "gpus": -1}
+        requests = resources.Resources(cores=1, memory=1024, gpus=2)
+        limits = resources.Resources(cores=2, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=no_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert (
+            f"Requested number of gpus cannot exceed the limit of {str(limits.gpus)} gpus."
+            in str(e_info.value)
+        )
+
+    def test_validate_resources_with_hard_limit_valid_resources(self, mocker):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        requests = resources.Resources(cores=1, memory=1024, gpus=0)
+        limits = resources.Resources(cores=2, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+
+    def test_validate_resources_with_hard_limit_invalid_cores_limit(self, mocker):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        requests = resources.Resources(cores=2, memory=1024, gpus=0)
+        limits = resources.Resources(cores=0, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert "Limit number of cores must be greater than 0 cores." in str(
+            e_info.value
+        )
+
+    def test_validate_resources_with_hard_limit_invalid_memory_limit(self, mocker):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        requests = resources.Resources(cores=2, memory=1024, gpus=0)
+        limits = resources.Resources(cores=1, memory=0, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert "Limit memory resources must be greater than 0 MB." in str(e_info.value)
+
+    def test_validate_resources_with_hard_limit_invalid_gpus_limit(self, mocker):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        requests = resources.Resources(cores=2, memory=1024, gpus=0)
+        limits = resources.Resources(cores=1, memory=2048, gpus=-1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert "Limit number of gpus must be greater than or equal to 0 gpus." in str(
+            e_info.value
+        )
+
+    def test_validate_resources_with_hard_limit_invalid_cores_request(self, mocker):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        requests = resources.Resources(cores=2, memory=1024, gpus=0)
+        limits = resources.Resources(cores=4, memory=2048, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert (
+            f"Limit number of cores cannot exceed the maximum of {hard_limit_res['cores']} cores."
+            in str(e_info.value)
+        )
+
+    def test_validate_resources_with_hard_limit_invalid_memory_request(self, mocker):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        requests = resources.Resources(cores=2, memory=1024, gpus=0)
+        limits = resources.Resources(cores=3, memory=4076, gpus=1)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert (
+            f"Limit memory resources cannot exceed the maximum of {hard_limit_res['memory']} MB."
+            in str(e_info.value)
+        )
+
+    def test_validate_resources_with_hard_limit_invalid_gpus_request(self, mocker):
+        # Arrange
+        hard_limit_res = {"cores": 3, "memory": 3072, "gpus": 3}
+        requests = resources.Resources(cores=2, memory=1024, gpus=0)
+        limits = resources.Resources(cores=3, memory=2048, gpus=4)
+        mock_get_serving_res_limits = mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=hard_limit_res,  # upper limit
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            resources.ComponentResources._validate_resources(requests, limits)
+
+        # Assert
+        mock_get_serving_res_limits.assert_called_once()
+        assert (
+            f"Limit number of gpus cannot exceed the maximum of {hard_limit_res['gpus']} gpus."
+            in str(e_info.value)
+        )
+
+    # PredictorResources
+
+    def test_from_response_json_predictor_resources(self, mocker, backend_fixtures):
+        mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=SERVING_RESOURCE_LIMITS,
+        )
+        json = backend_fixtures["resources"][
+            "get_component_resources_num_instances_requests_and_limits"
+        ]["response"]
+
+        # Act
+        r = resources.PredictorResources.from_response_json(json)
+
+        # Assert
+        assert r.num_instances == json["num_instances"]
+        assert r.requests.cores == json["requests"]["cores"]
+        assert r.requests.memory == json["requests"]["memory"]
+        assert r.requests.gpus == json["requests"]["gpus"]
+        assert r.limits.cores == json["limits"]["cores"]
+        assert r.limits.memory == json["limits"]["memory"]
+        assert r.limits.gpus == json["limits"]["gpus"]
+
+    def test_from_response_json_predictor_resources_specific_keys(
+        self, mocker, backend_fixtures
+    ):
+        mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=SERVING_RESOURCE_LIMITS,
+        )
+        json = backend_fixtures["resources"][
+            "get_component_resources_requested_instances_and_predictor_resources"
+        ]["response"]
+
+        # Act
+        r = resources.PredictorResources.from_response_json(json)
+
+        # Assert
+        assert r.num_instances == json["requested_instances"]
+        assert r.requests.cores == json["predictor_resources"]["requests"]["cores"]
+        assert r.requests.memory == json["predictor_resources"]["requests"]["memory"]
+        assert r.requests.gpus == json["predictor_resources"]["requests"]["gpus"]
+        assert r.limits.cores == json["predictor_resources"]["limits"]["cores"]
+        assert r.limits.memory == json["predictor_resources"]["limits"]["memory"]
+        assert r.limits.gpus == json["predictor_resources"]["limits"]["gpus"]
+
+    # TransformerResources
+
+    def test_from_response_json_transformer_resources(self, mocker, backend_fixtures):
+        mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=SERVING_RESOURCE_LIMITS,
+        )
+        json = backend_fixtures["resources"][
+            "get_component_resources_num_instances_requests_and_limits"
+        ]["response"]
+
+        # Act
+        r = resources.TransformerResources.from_response_json(json)
+
+        # Assert
+        assert r.num_instances == json["num_instances"]
+        assert r.requests.cores == json["requests"]["cores"]
+        assert r.requests.memory == json["requests"]["memory"]
+        assert r.requests.gpus == json["requests"]["gpus"]
+        assert r.limits.cores == json["limits"]["cores"]
+        assert r.limits.memory == json["limits"]["memory"]
+        assert r.limits.gpus == json["limits"]["gpus"]
+
+    def test_from_response_json_transformer_resources_specific_keys(
+        self, mocker, backend_fixtures
+    ):
+        mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=SERVING_RESOURCE_LIMITS,
+        )
+        json = backend_fixtures["resources"][
+            "get_component_resources_requested_instances_and_transformer_resources"
+        ]["response"]
+
+        # Act
+        r = resources.TransformerResources.from_response_json(json)
+
+        # Assert
+        assert r.num_instances == json["requested_transformer_instances"]
+        assert r.requests.cores == json["transformer_resources"]["requests"]["cores"]
+        assert r.requests.memory == json["transformer_resources"]["requests"]["memory"]
+        assert r.requests.gpus == json["transformer_resources"]["requests"]["gpus"]
+        assert r.limits.cores == json["transformer_resources"]["limits"]["cores"]
+        assert r.limits.memory == json["transformer_resources"]["limits"]["memory"]
+        assert r.limits.gpus == json["transformer_resources"]["limits"]["gpus"]
+
+    def test_from_response_json_transformer_resources_default_limits(
+        self, mocker, backend_fixtures
+    ):
+        mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=SERVING_RESOURCE_LIMITS,
+        )
+        mocker.patch(
+            "hsml.resources.ComponentResources._get_default_resource_limits",
+            return_value=resources.Resources(
+                cores=SERVING_RESOURCE_LIMITS["cores"],
+                memory=SERVING_RESOURCE_LIMITS["memory"],
+                gpus=SERVING_RESOURCE_LIMITS["gpus"],
+            ),
+        )
+        json = backend_fixtures["resources"][
+            "get_component_resources_num_instances_and_requests"
+        ]["response"]
+
+        # Act
+        r = resources.TransformerResources.from_response_json(json)
+
+        # Assert
+        assert r.num_instances == json["num_instances"]
+        assert r.requests.cores == json["requests"]["cores"]
+        assert r.requests.memory == json["requests"]["memory"]
+        assert r.requests.gpus == json["requests"]["gpus"]
+        assert r.limits.cores == SERVING_RESOURCE_LIMITS["cores"]
+        assert r.limits.memory == SERVING_RESOURCE_LIMITS["memory"]
+        assert r.limits.gpus == SERVING_RESOURCE_LIMITS["gpus"]

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -1,0 +1,201 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import numpy as np
+
+from hsml import schema
+
+
+class TestSchema:
+
+    # constructor
+
+    def test_constructor_default(self, mocker):
+        # Arrange
+        mock_tensor = mocker.MagicMock()
+        mock_tensor.tensors = mocker.MagicMock(return_value="tensor_schema")
+        mock_columnar = mocker.MagicMock()
+        mock_columnar.columns = mocker.MagicMock(return_value="columnar_schema")
+        mock_convert_tensor_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_tensor_to_schema", return_value=mock_tensor
+        )
+        mock_convert_columnar_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_columnar_to_schema",
+            return_value=mock_columnar,
+        )
+
+        # Act
+        s = schema.Schema()
+
+        # Assert
+        assert s.columnar_schema == mock_columnar.columns
+        assert not hasattr(s, "tensor_schema")
+        mock_convert_tensor_to_schema.assert_not_called()
+        mock_convert_columnar_to_schema.assert_called_once_with(None)
+
+    def test_constructor_numpy(self, mocker):
+        # Arrange
+        obj = np.array([])
+        mock_tensor = mocker.MagicMock()
+        mock_tensor.tensors = mocker.MagicMock(return_value="tensor_schema")
+        mock_columnar = mocker.MagicMock()
+        mock_columnar.columns = mocker.MagicMock(return_value="columnar_schema")
+        mock_convert_tensor_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_tensor_to_schema", return_value=mock_tensor
+        )
+        mock_convert_columnar_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_columnar_to_schema",
+            return_value=mock_columnar,
+        )
+
+        # Act
+        s = schema.Schema(obj)
+
+        # Assert
+        assert s.tensor_schema == mock_tensor.tensors
+        assert not hasattr(s, "columnar_schema")
+        mock_convert_columnar_to_schema.assert_not_called()
+        mock_convert_tensor_to_schema.assert_called_once_with(obj)
+
+    def test_constructor_tensor_list(self, mocker):
+        # Arrange
+        obj = [{"shape": "some_shape"}]
+        mock_tensor = mocker.MagicMock()
+        mock_tensor.tensors = mocker.MagicMock(return_value="tensor_schema")
+        mock_columnar = mocker.MagicMock()
+        mock_columnar.columns = mocker.MagicMock(return_value="columnar_schema")
+        mock_convert_tensor_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_tensor_to_schema", return_value=mock_tensor
+        )
+        mock_convert_columnar_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_columnar_to_schema",
+            return_value=mock_columnar,
+        )
+
+        # Act
+        s = schema.Schema(obj)
+
+        # Assert
+        assert s.tensor_schema == mock_tensor.tensors
+        assert not hasattr(s, "columnar_schema")
+        mock_convert_columnar_to_schema.assert_not_called()
+        mock_convert_tensor_to_schema.assert_called_once_with(obj)
+
+    def test_constructor_column_list(self, mocker):
+        # Arrange
+        obj = [{"no_shape": "nothing"}]
+        mock_tensor = mocker.MagicMock()
+        mock_tensor.tensors = mocker.MagicMock(return_value="tensor_schema")
+        mock_columnar = mocker.MagicMock()
+        mock_columnar.columns = mocker.MagicMock(return_value="columnar_schema")
+        mock_convert_tensor_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_tensor_to_schema", return_value=mock_tensor
+        )
+        mock_convert_columnar_to_schema = mocker.patch(
+            "hsml.schema.Schema._convert_columnar_to_schema",
+            return_value=mock_columnar,
+        )
+
+        # Act
+        s = schema.Schema(obj)
+
+        # Assert
+        assert s.columnar_schema == mock_columnar.columns
+        assert not hasattr(s, "tensor_schema")
+        mock_convert_tensor_to_schema.assert_not_called()
+        mock_convert_columnar_to_schema.assert_called_once_with(obj)
+
+    # convert to schema
+
+    def test_convert_columnar_to_schema(self, mocker):
+        # Arrange
+        obj = {"key": "value"}
+        mock_columnar_schema_init = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema.__init__",
+            return_value=None,
+        )
+        mock_schema = mocker.MagicMock()
+        mock_schema._convert_columnar_to_schema = (
+            schema.Schema._convert_columnar_to_schema
+        )
+
+        # Act
+        ret = mock_schema._convert_columnar_to_schema(mock_schema, obj)
+
+        # Assert
+        assert isinstance(ret, schema.ColumnarSchema)
+        mock_columnar_schema_init.assert_called_once_with(obj)
+
+    def test_convert_tensor_to_schema(self, mocker):
+        # Arrange
+        obj = {"key": "value"}
+        mock_tensor_schema_init = mocker.patch(
+            "hsml.utils.schema.tensor_schema.TensorSchema.__init__",
+            return_value=None,
+        )
+        mock_schema = mocker.MagicMock()
+        mock_schema._convert_tensor_to_schema = schema.Schema._convert_tensor_to_schema
+
+        # Act
+        ret = mock_schema._convert_tensor_to_schema(mock_schema, obj)
+
+        # Assert
+        assert isinstance(ret, schema.TensorSchema)
+        mock_tensor_schema_init.assert_called_once_with(obj)
+
+    # get type
+
+    def test_get_type_none(self, mocker):
+        # Arrange
+        class MockSchema:
+            pass
+
+        mock_schema = MockSchema()
+        mock_schema._get_type = schema.Schema._get_type
+
+        # Act
+        t = mock_schema._get_type(mock_schema)
+
+        # Assert
+        assert t is None
+
+    def test_get_type_tensor(self, mocker):
+        # Arrange
+        class MockSchema:
+            tensor_schema = {}
+
+        mock_schema = MockSchema()
+        mock_schema._get_type = schema.Schema._get_type
+
+        # Act
+        t = mock_schema._get_type(mock_schema)
+
+        # Assert
+        assert t == "tensor"
+
+    def test_get_type_columnar(self, mocker):
+        # Arrange
+        class MockSchema:
+            columnar_schema = {}
+
+        mock_schema = MockSchema()
+        mock_schema._get_type = schema.Schema._get_type
+
+        # Act
+        t = mock_schema._get_type(mock_schema)
+
+        # Assert
+        assert t == "columnar"

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -15,12 +15,10 @@
 #
 
 import numpy as np
-
 from hsml import schema
 
 
 class TestSchema:
-
     # constructor
 
     def test_constructor_default(self, mocker):

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -15,12 +15,10 @@
 #
 
 import humps
-
 from hsml import tag
 
 
 class TestTag:
-
     # from response json
 
     def test_from_response_json(self, backend_fixtures):

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -1,0 +1,64 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import humps
+
+from hsml import tag
+
+
+class TestTag:
+
+    # from response json
+
+    def test_from_response_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["tag"]["get"]["response"]
+        json_camelized = humps.camelize(json)
+
+        # Act
+        t_list = tag.Tag.from_response_json(json_camelized)
+
+        # Assert
+        assert len(t_list) == 1
+        t = t_list[0]
+        assert t.name == "test_name"
+        assert t.value == "test_value"
+
+    def test_from_response_json_empty(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["tag"]["get_empty"]["response"]
+        json_camelized = humps.camelize(json)
+
+        # Act
+        t_list = tag.Tag.from_response_json(json_camelized)
+
+        # Assert
+        assert len(t_list) == 0
+
+    # constructor
+
+    def test_constructor(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["tag"]["get"]["response"]["items"][0]
+        tag_name = json.pop("name")
+        tag_value = json.pop("value")
+
+        # Act
+        t = tag.Tag(name=tag_name, value=tag_value, **json)
+
+        # Assert
+        assert t.name == "test_name"
+        assert t.value == "test_value"

--- a/python/tests/test_transformer.py
+++ b/python/tests/test_transformer.py
@@ -14,12 +14,12 @@
 #   limitations under the License.
 #
 
-import pytest
 import copy
 
-from hsml import transformer
-from hsml import resources
+import pytest
+from hsml import resources, transformer
 from hsml.constants import RESOURCES
+
 
 SERVING_RESOURCE_LIMITS = {"cores": 2, "memory": 1024, "gpus": 2}
 SERVING_NUM_INSTANCES_NO_LIMIT = [-1]
@@ -28,7 +28,6 @@ SERVING_NUM_INSTANCES_ONE = [0]
 
 
 class TestTransformer:
-
     # from response json
 
     def test_from_response_json_with_transformer_field(self, mocker, backend_fixtures):

--- a/python/tests/test_transformer.py
+++ b/python/tests/test_transformer.py
@@ -1,0 +1,310 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+import copy
+
+from hsml import transformer
+from hsml import resources
+from hsml.constants import RESOURCES
+
+SERVING_RESOURCE_LIMITS = {"cores": 2, "memory": 1024, "gpus": 2}
+SERVING_NUM_INSTANCES_NO_LIMIT = [-1]
+SERVING_NUM_INSTANCES_SCALE_TO_ZERO = [0]
+SERVING_NUM_INSTANCES_ONE = [0]
+
+
+class TestTransformer:
+
+    # from response json
+
+    def test_from_response_json_with_transformer_field(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        json = backend_fixtures["transformer"]["get_deployment_with_transformer"][
+            "response"
+        ]
+
+        # Act
+        t = transformer.Transformer.from_response_json(json)
+
+        # Assert
+        assert isinstance(t, transformer.Transformer)
+        assert t.script_file == json["transformer"]
+
+        tr_resources = json["transformer_resources"]
+        assert (
+            t.resources.num_instances == tr_resources["requested_transformer_instances"]
+        )
+        assert t.resources.requests.cores == tr_resources["requests"]["cores"]
+        assert t.resources.requests.memory == tr_resources["requests"]["memory"]
+        assert t.resources.requests.gpus == tr_resources["requests"]["gpus"]
+        assert t.resources.limits.cores == tr_resources["limits"]["cores"]
+        assert t.resources.limits.memory == tr_resources["limits"]["memory"]
+        assert t.resources.limits.gpus == tr_resources["limits"]["gpus"]
+
+    def test_from_response_json_with_script_file_field(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        json = backend_fixtures["transformer"]["get_transformer_with_resources"][
+            "response"
+        ]
+
+        # Act
+        t = transformer.Transformer.from_response_json(json)
+
+        # Assert
+        assert isinstance(t, transformer.Transformer)
+        assert t.script_file == json["script_file"]
+
+        tr_resources = json["resources"]
+        assert t.resources.num_instances == tr_resources["num_instances"]
+        assert t.resources.requests.cores == tr_resources["requests"]["cores"]
+        assert t.resources.requests.memory == tr_resources["requests"]["memory"]
+        assert t.resources.requests.gpus == tr_resources["requests"]["gpus"]
+        assert t.resources.limits.cores == tr_resources["limits"]["cores"]
+        assert t.resources.limits.memory == tr_resources["limits"]["memory"]
+        assert t.resources.limits.gpus == tr_resources["limits"]["gpus"]
+
+    def test_from_response_json_empty(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        json = backend_fixtures["transformer"]["get_deployment_without_transformer"][
+            "response"
+        ]
+
+        # Act
+        t = transformer.Transformer.from_response_json(json)
+
+        # Assert
+        assert t is None
+
+    def test_from_response_json_default_resources(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        json = backend_fixtures["transformer"]["get_transformer_without_resources"][
+            "response"
+        ]
+
+        # Act
+        t = transformer.Transformer.from_response_json(json)
+
+        # Assert
+        assert isinstance(t, transformer.Transformer)
+        assert t.script_file == json["script_file"]
+
+        assert t.resources.num_instances == RESOURCES.MIN_NUM_INSTANCES
+        assert t.resources.requests.cores == RESOURCES.MIN_CORES
+        assert t.resources.requests.memory == RESOURCES.MIN_MEMORY
+        assert t.resources.requests.gpus == RESOURCES.MIN_GPUS
+        assert t.resources.limits.cores == RESOURCES.MAX_CORES
+        assert t.resources.limits.memory == RESOURCES.MAX_MEMORY
+        assert t.resources.limits.gpus == RESOURCES.MAX_GPUS
+
+    # constructor
+
+    def test_constructor_default_resources(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        json = backend_fixtures["transformer"]["get_transformer_without_resources"][
+            "response"
+        ]
+
+        # Act
+        t = transformer.Transformer(json["script_file"], resources=None)
+
+        # Assert
+        assert t.script_file == json["script_file"]
+
+        assert t.resources.num_instances == RESOURCES.MIN_NUM_INSTANCES
+        assert t.resources.requests.cores == RESOURCES.MIN_CORES
+        assert t.resources.requests.memory == RESOURCES.MIN_MEMORY
+        assert t.resources.requests.gpus == RESOURCES.MIN_GPUS
+        assert t.resources.limits.cores == RESOURCES.MAX_CORES
+        assert t.resources.limits.memory == RESOURCES.MAX_MEMORY
+        assert t.resources.limits.gpus == RESOURCES.MAX_GPUS
+
+    def test_constructor_default_resources_when_scale_to_zero_is_required(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+        json = backend_fixtures["transformer"]["get_transformer_without_resources"][
+            "response"
+        ]
+
+        # Act
+        t = transformer.Transformer(json["script_file"], resources=None)
+
+        # Assert
+        assert t.script_file == json["script_file"]
+
+        assert t.resources.num_instances == 0
+        assert t.resources.requests.cores == RESOURCES.MIN_CORES
+        assert t.resources.requests.memory == RESOURCES.MIN_MEMORY
+        assert t.resources.requests.gpus == RESOURCES.MIN_GPUS
+        assert t.resources.limits.cores == RESOURCES.MAX_CORES
+        assert t.resources.limits.memory == RESOURCES.MAX_MEMORY
+        assert t.resources.limits.gpus == RESOURCES.MAX_GPUS
+
+    # validate resources
+
+    def test_validate_resources_none(self):
+        # Act
+        res = transformer.Transformer._validate_resources(None)
+
+        # Assert
+        assert res is None
+
+    def test_validate_resources_num_instances_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        tr = resources.TransformerResources(num_instances=0)
+
+        # Act
+        res = transformer.Transformer._validate_resources(tr)
+
+        # Assert
+        assert res == tr
+
+    def test_validate_resources_num_instances_one_without_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        tr = resources.TransformerResources(num_instances=1)
+
+        # Act
+        res = transformer.Transformer._validate_resources(tr)
+
+        # Assert
+        assert res == tr
+
+    def test_validate_resources_num_instances_one_with_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+        tr = resources.TransformerResources(num_instances=1)
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = transformer.Transformer._validate_resources(tr)
+
+        # Assert
+        assert "Scale-to-zero is required" in str(e_info.value)
+
+    # default num instances
+
+    def test_get_default_num_instances_without_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+
+        # Act
+        num_instances = transformer.Transformer._get_default_num_instances()
+
+        # Assert
+        assert num_instances == RESOURCES.MIN_NUM_INSTANCES
+
+    def test_get_default_num_instances_with_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        num_instances = transformer.Transformer._get_default_num_instances()
+
+        # Assert
+        assert num_instances == 0
+
+    # default resources
+
+    def test_get_default_resources_without_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+
+        # Act
+        res = transformer.Transformer._get_default_resources()
+
+        # Assert
+        assert isinstance(res, resources.TransformerResources)
+        assert res.num_instances == RESOURCES.MIN_NUM_INSTANCES
+
+    def test_get_default_resources_with_scale_to_zero(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        res = transformer.Transformer._get_default_resources()
+
+        # Assert
+        assert isinstance(res, resources.TransformerResources)
+        assert res.num_instances == 0
+
+    # extract fields from json
+
+    def test_extract_fields_from_json(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        json = backend_fixtures["transformer"]["get_deployment_with_transformer"][
+            "response"
+        ]
+        json_copy = copy.deepcopy(json)
+
+        # Act
+        sf, rc = transformer.Transformer.extract_fields_from_json(json_copy)
+
+        # Assert
+        assert sf == json["transformer"]
+        assert isinstance(rc, resources.TransformerResources)
+
+        tr_resources = json["transformer_resources"]
+        assert rc.num_instances == tr_resources["requested_transformer_instances"]
+        assert rc.requests.cores == tr_resources["requests"]["cores"]
+        assert rc.requests.memory == tr_resources["requests"]["memory"]
+        assert rc.requests.gpus == tr_resources["requests"]["gpus"]
+        assert rc.limits.cores == tr_resources["limits"]["cores"]
+        assert rc.limits.memory == tr_resources["limits"]["memory"]
+        assert rc.limits.gpus == tr_resources["limits"]["gpus"]
+
+    # auxiliary methods
+
+    def _mock_serving_variables(self, mocker, num_instances, force_scale_to_zero=False):
+        mocker.patch(
+            "hsml.client.get_serving_resource_limits",
+            return_value=SERVING_RESOURCE_LIMITS,
+        )
+        mocker.patch(
+            "hsml.client.get_serving_num_instances_limits", return_value=num_instances
+        )
+        mocker.patch(
+            "hsml.client.is_scale_to_zero_required", return_value=force_scale_to_zero
+        )

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -1,0 +1,645 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+from urllib.parse import ParseResult
+
+from hsml import util
+from hsml.constants import MODEL
+
+from hsml.model import Model as BaseModel
+from hsml.python.model import Model as PythonModel
+from hsml.sklearn.model import Model as SklearnModel
+from hsml.tensorflow.model import Model as TensorflowModel
+from hsml.torch.model import Model as TorchModel
+
+from hsml.predictor import Predictor as BasePredictor
+from hsml.tensorflow.predictor import Predictor as TFPredictor
+from hsml.torch.predictor import Predictor as TorchPredictor
+from hsml.sklearn.predictor import Predictor as SkLearnPredictor
+from hsml.python.predictor import Predictor as PyPredictor
+
+
+class TestUtil:
+
+    # schema and types
+
+    # - set_model_class
+
+    def test_set_model_class_base(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_base"]["response"]["items"][0]
+
+        # Act
+        model = util.set_model_class(json)
+
+        # Assert
+        assert isinstance(model, BaseModel)
+        assert model.framework is None
+
+    def test_set_model_class_python(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+
+        # Act
+        model = util.set_model_class(json)
+
+        # Assert
+        assert isinstance(model, PythonModel)
+        assert model.framework == MODEL.FRAMEWORK_PYTHON
+
+    def test_set_model_class_sklearn(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_sklearn"]["response"]["items"][0]
+
+        # Act
+        model = util.set_model_class(json)
+
+        # Assert
+        assert isinstance(model, SklearnModel)
+        assert model.framework == MODEL.FRAMEWORK_SKLEARN
+
+    def test_set_model_class_tensorflow(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_tensorflow"]["response"]["items"][0]
+
+        # Act
+        model = util.set_model_class(json)
+
+        # Assert
+        assert isinstance(model, TensorflowModel)
+        assert model.framework == MODEL.FRAMEWORK_TENSORFLOW
+
+    def test_set_model_class_torch(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_torch"]["response"]["items"][0]
+
+        # Act
+        model = util.set_model_class(json)
+
+        # Assert
+        assert isinstance(model, TorchModel)
+        assert model.framework == MODEL.FRAMEWORK_TORCH
+
+    def test_set_model_class_unsupported(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["model"]["get_base"]["response"]["items"][0]
+        json["framework"] = "UNSUPPORTED"
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            util.set_model_class(json)
+
+        # Assert
+        assert "is not a supported framework" in str(e_info.value)
+
+    # - input_example_to_json
+
+    def test_input_example_to_json_from_numpy(self, mocker, input_example_numpy):
+        # Arrange
+        mock_handle_tensor_input = mocker.patch("hsml.util._handle_tensor_input")
+        mock_handle_dataframe_input = mocker.patch("hsml.util._handle_dataframe_input")
+        mock_handle_dict_input = mocker.patch("hsml.util._handle_dict_input")
+
+        # Act
+        util.input_example_to_json(input_example_numpy)
+
+        # Assert
+        mock_handle_tensor_input.assert_called_once()
+        mock_handle_dict_input.assert_not_called()
+        mock_handle_dataframe_input.assert_not_called()
+
+    def test_input_example_to_json_from_dict(self, mocker, input_example_dict):
+        # Arrange
+        mock_handle_tensor_input = mocker.patch("hsml.util._handle_tensor_input")
+        mock_handle_dataframe_input = mocker.patch("hsml.util._handle_dataframe_input")
+        mock_handle_dict_input = mocker.patch("hsml.util._handle_dict_input")
+
+        # Act
+        util.input_example_to_json(input_example_dict)
+
+        # Assert
+        mock_handle_tensor_input.assert_not_called()
+        mock_handle_dict_input.assert_called_once()
+        mock_handle_dataframe_input.assert_not_called()
+
+    def test_input_example_to_json_from_dataframe(
+        self, mocker, input_example_dataframe_pandas_dataframe
+    ):
+        # Arrange
+        mock_handle_tensor_input = mocker.patch("hsml.util._handle_tensor_input")
+        mock_handle_dataframe_input = mocker.patch("hsml.util._handle_dataframe_input")
+        mock_handle_dict_input = mocker.patch("hsml.util._handle_dict_input")
+
+        # Act
+        util.input_example_to_json(input_example_dataframe_pandas_dataframe)
+
+        # Assert
+        mock_handle_tensor_input.assert_not_called()
+        mock_handle_dict_input.assert_not_called()
+        mock_handle_dataframe_input.assert_called_once()  # default
+
+    def test_input_example_to_json_unsupported(self, mocker):
+        # Arrange
+        mock_handle_tensor_input = mocker.patch("hsml.util._handle_tensor_input")
+        mock_handle_dataframe_input = mocker.patch("hsml.util._handle_dataframe_input")
+        mock_handle_dict_input = mocker.patch("hsml.util._handle_dict_input")
+
+        # Act
+        util.input_example_to_json(lambda unsupported_type: None)
+
+        # Assert
+        mock_handle_tensor_input.assert_not_called()
+        mock_handle_dict_input.assert_not_called()
+        mock_handle_dataframe_input.assert_called_once()  # default
+
+    # - handle input examples
+
+    def test_handle_dataframe_input_pandas_dataframe(
+        self,
+        input_example_dataframe_pandas_dataframe,
+        input_example_dataframe_pandas_dataframe_empty,
+        input_example_dataframe_list,
+    ):
+        # Act
+        json = util._handle_dataframe_input(input_example_dataframe_pandas_dataframe)
+        with pytest.raises(ValueError) as e_info:
+            util._handle_dataframe_input(input_example_dataframe_pandas_dataframe_empty)
+
+        # Assert
+        assert isinstance(json, list)
+        assert json == input_example_dataframe_list
+        assert "can not be empty" in str(e_info.value)
+
+    def test_handle_dataframe_input_pandas_dataframe_series(
+        self,
+        input_example_dataframe_pandas_series,
+        input_example_dataframe_pandas_series_empty,
+        input_example_dataframe_list,
+    ):
+        # Act
+        json = util._handle_dataframe_input(input_example_dataframe_pandas_series)
+        with pytest.raises(ValueError) as e_info:
+            util._handle_dataframe_input(input_example_dataframe_pandas_series_empty)
+
+        # Assert
+        assert isinstance(json, list)
+        assert json == input_example_dataframe_list
+        assert "can not be empty" in str(e_info.value)
+
+    def test_handle_dataframe_input_list(self, input_example_dataframe_list):
+        # Act
+        json = util._handle_dataframe_input(input_example_dataframe_list)
+
+        # Assert
+        assert isinstance(json, list)
+        assert json == input_example_dataframe_list
+
+    def test_handle_dataframe_input_unsupported(self):
+        # Act
+        with pytest.raises(TypeError) as e_info:
+            util._handle_dataframe_input(lambda unsupported: None)
+
+        # Assert
+        assert "is not a supported input example type" in str(e_info.value)
+
+    def test_handle_tensor_input(
+        self, input_example_numpy, input_example_dataframe_list
+    ):
+        # Act
+        json = util._handle_tensor_input(input_example_numpy)
+
+        # Assert
+        assert isinstance(json, list)
+        assert json == input_example_dataframe_list
+
+    def test_handle_dict_input(self, input_example_dict):
+        # Act
+        json = util._handle_dict_input(input_example_dict)
+
+        # Assert
+        assert isinstance(json, dict)
+        assert json == input_example_dict
+
+    # artifacts
+
+    def test_compress_dir(self, mocker):
+        # Arrange
+        archive_name = "archive_name"
+        path_to_archive = "this/is/the/path/to/archive"
+        archive_out_path = "this/is/the/output/path/to/archive"
+        full_archive_out_path = f"{archive_out_path}/{archive_name}"
+        mock_isdir = mocker.patch("os.path.isdir", return_value=True)
+        mock_shutil_make_archive = mocker.patch(
+            "shutil.make_archive", return_value="resulting_path"
+        )
+
+        # Act
+        path = util.compress(archive_out_path, archive_name, path_to_archive)
+
+        # Assert
+        assert path == "resulting_path"
+        mock_isdir.assert_called_once_with(path_to_archive)
+        mock_shutil_make_archive.assert_called_once_with(
+            full_archive_out_path, "gztar", path_to_archive
+        )
+
+    def test_compress_file(self, mocker):
+        # Arrange
+        archive_name = "archive_name"
+        path_to_archive = "path/to/archive"
+        archive_out_path = "output/path/to/archive"
+        full_archive_out_path = f"{archive_out_path}/{archive_name}"
+        archive_path_dirname = "path/to"
+        archive_path_basename = "archive"
+        mock_isdir = mocker.patch("os.path.isdir", return_value=False)
+        mock_shutil_make_archive = mocker.patch(
+            "shutil.make_archive", return_value="resulting_path"
+        )
+
+        # Act
+        path = util.compress(archive_out_path, archive_name, path_to_archive)
+
+        # Assert
+        assert path == "resulting_path"
+        mock_isdir.assert_called_once_with(path_to_archive)
+        mock_shutil_make_archive.assert_called_once_with(
+            full_archive_out_path, "gztar", archive_path_dirname, archive_path_basename
+        )
+
+    def test_decompress(self, mocker):
+        # Arrange
+        archive_file_path = "path/to/archive/file"
+        extract_dir = False
+        mock_shutil_unpack_archive = mocker.patch(
+            "shutil.unpack_archive", return_value="resulting_path"
+        )
+
+        # Act
+        path = util.decompress(archive_file_path, extract_dir)
+
+        # Assert
+        assert path == "resulting_path"
+        mock_shutil_unpack_archive.assert_called_once_with(
+            archive_file_path, extract_dir=extract_dir
+        )
+
+    # export models
+
+    def test_validate_metrics(self, model_metrics):
+        # Act
+        util.validate_metrics(model_metrics)
+
+        # Assert
+        # noop
+
+    def test_validate_metrics_unsupported_type(self, model_metrics_wrong_type):
+        # Act
+        with pytest.raises(TypeError) as e_info:
+            util.validate_metrics(model_metrics_wrong_type)
+
+        # Assert
+        assert "expected a dict" in str(e_info.value)
+
+    def test_validate_metrics_unsupported_metric_type(
+        self, model_metrics_wrong_metric_type
+    ):
+        # Act
+        with pytest.raises(TypeError) as e_info:
+            util.validate_metrics(model_metrics_wrong_metric_type)
+
+        # Assert
+        assert "expected a string" in str(e_info.value)
+
+    def test_validate_metrics_unsupported_metric_value(
+        self, model_metrics_wrong_metric_value
+    ):
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            util.validate_metrics(model_metrics_wrong_metric_value)
+
+        # Assert
+        assert "is not a number" in str(e_info.value)
+
+    # model serving
+
+    def test_get_predictor_for_model_base(self, mocker, model_base):
+        # Arrange
+        def pred_base_spec(model_framework, model_server):
+            pass
+
+        pred_base = mocker.patch(
+            "hsml.predictor.Predictor.__init__", return_value=None, spec=pred_base_spec
+        )
+        pred_python = mocker.patch("hsml.python.predictor.Predictor.__init__")
+        pred_sklearn = mocker.patch("hsml.sklearn.predictor.Predictor.__init__")
+        pred_tensorflow = mocker.patch("hsml.tensorflow.predictor.Predictor.__init__")
+        pred_torch = mocker.patch("hsml.torch.predictor.Predictor.__init__")
+
+        # Act
+        predictor = util.get_predictor_for_model(model_base)
+
+        # Assert
+        assert isinstance(predictor, BasePredictor)
+        pred_base.assert_called_once_with(
+            model_framework=MODEL.FRAMEWORK_PYTHON, model_server=MODEL.FRAMEWORK_PYTHON
+        )
+        pred_python.assert_not_called()
+        pred_sklearn.assert_not_called()
+        pred_tensorflow.assert_not_called()
+        pred_torch.assert_not_called()
+
+    def test_get_predictor_for_model_python(self, mocker, model_python):
+        # Arrange
+        pred_base = mocker.patch("hsml.predictor.Predictor.__init__")
+        pred_python = mocker.patch(
+            "hsml.python.predictor.Predictor.__init__", return_value=None
+        )
+        pred_sklearn = mocker.patch("hsml.sklearn.predictor.Predictor.__init__")
+        pred_tensorflow = mocker.patch("hsml.tensorflow.predictor.Predictor.__init__")
+        pred_torch = mocker.patch("hsml.torch.predictor.Predictor.__init__")
+
+        # Act
+        predictor = util.get_predictor_for_model(model_python)
+
+        # Assert
+        assert isinstance(predictor, PyPredictor)
+        pred_base.assert_not_called()
+        pred_python.assert_called_once()
+        pred_sklearn.assert_not_called()
+        pred_tensorflow.assert_not_called()
+        pred_torch.assert_not_called()
+
+    def test_get_predictor_for_model_sklearn(self, mocker, model_sklearn):
+        # Arrange
+        pred_base = mocker.patch("hsml.predictor.Predictor.__init__")
+        pred_python = mocker.patch("hsml.python.predictor.Predictor.__init__")
+        pred_sklearn = mocker.patch(
+            "hsml.sklearn.predictor.Predictor.__init__", return_value=None
+        )
+        pred_tensorflow = mocker.patch("hsml.tensorflow.predictor.Predictor.__init__")
+        pred_torch = mocker.patch("hsml.torch.predictor.Predictor.__init__")
+
+        # Act
+        predictor = util.get_predictor_for_model(model_sklearn)
+
+        # Assert
+        assert isinstance(predictor, SkLearnPredictor)
+        pred_base.assert_not_called()
+        pred_python.assert_not_called()
+        pred_sklearn.assert_called_once()
+        pred_tensorflow.assert_not_called()
+        pred_torch.assert_not_called()
+
+    def test_get_predictor_for_model_tensorflow(self, mocker, model_tensorflow):
+        # Arrange
+        pred_base = mocker.patch("hsml.predictor.Predictor.__init__")
+        pred_python = mocker.patch("hsml.python.predictor.Predictor.__init__")
+        pred_sklearn = mocker.patch("hsml.sklearn.predictor.Predictor.__init__")
+        pred_tensorflow = mocker.patch(
+            "hsml.tensorflow.predictor.Predictor.__init__", return_value=None
+        )
+        pred_torch = mocker.patch("hsml.torch.predictor.Predictor.__init__")
+
+        # Act
+        predictor = util.get_predictor_for_model(model_tensorflow)
+
+        # Assert
+        assert isinstance(predictor, TFPredictor)
+        pred_base.assert_not_called()
+        pred_python.assert_not_called()
+        pred_sklearn.assert_not_called()
+        pred_tensorflow.assert_called_once()
+        pred_torch.assert_not_called()
+
+    def test_get_predictor_for_model_torch(self, mocker, model_torch):
+        # Arrange
+        pred_base = mocker.patch("hsml.predictor.Predictor.__init__")
+        pred_python = mocker.patch("hsml.python.predictor.Predictor.__init__")
+        pred_sklearn = mocker.patch("hsml.sklearn.predictor.Predictor.__init__")
+        pred_tensorflow = mocker.patch("hsml.tensorflow.predictor.Predictor.__init__")
+        pred_torch = mocker.patch(
+            "hsml.torch.predictor.Predictor.__init__", return_value=None
+        )
+
+        # Act
+        predictor = util.get_predictor_for_model(model_torch)
+
+        # Assert
+        assert isinstance(predictor, TorchPredictor)
+        pred_base.assert_not_called()
+        pred_python.assert_not_called()
+        pred_sklearn.assert_not_called()
+        pred_tensorflow.assert_not_called()
+        pred_torch.assert_called_once()
+
+    def test_get_predictor_for_model_non_base(self, mocker):
+        # Arrange
+        pred_base = mocker.patch("hsml.predictor.Predictor.__init__")
+        pred_python = mocker.patch("hsml.python.predictor.Predictor.__init__")
+        pred_sklearn = mocker.patch("hsml.sklearn.predictor.Predictor.__init__")
+        pred_tensorflow = mocker.patch("hsml.tensorflow.predictor.Predictor.__init__")
+        pred_torch = mocker.patch("hsml.torch.predictor.Predictor.__init__")
+
+        class NonBaseModel:
+            pass
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            util.get_predictor_for_model(NonBaseModel())
+
+        assert "an instance of {} class is expected".format(BaseModel) in str(
+            e_info.value
+        )
+        pred_base.assert_not_called()
+        pred_python.assert_not_called()
+        pred_sklearn.assert_not_called()
+        pred_tensorflow.assert_not_called()
+        pred_torch.assert_not_called()
+
+    def test_get_hostname_replaced_url(self, mocker):
+        # Arrange
+        sub_path = "this/is/a/sub_path"
+        base_url = "/hopsworks/api/base/"
+        urlparse_href_arg = ParseResult(
+            scheme="",
+            netloc="",
+            path=base_url + sub_path,
+            params="",
+            query="",
+            fragment="",
+        )
+        geturl_return = "final_url"
+        mock_url_parsed = mocker.MagicMock()
+        mock_url_parsed.geturl = mocker.MagicMock(return_value=geturl_return)
+        mock_client = mocker.MagicMock()
+        mock_client._base_url = base_url + "url"
+        mock_client._replace_public_host = mocker.MagicMock(
+            return_value=mock_url_parsed
+        )
+        mocker.patch("hsml.client.get_instance", return_value=mock_client)
+
+        # Act
+        url = util.get_hostname_replaced_url(sub_path)
+
+        # Assert
+        mock_client._replace_public_host.assert_called_once_with(urlparse_href_arg)
+        mock_url_parsed.geturl.assert_called_once()
+        assert url == geturl_return
+
+    # general
+
+    def test_get_members(self):
+        # Arrange
+        class TEST:
+            TEST_1 = 1
+            TEST_2 = "two"
+            TEST_3 = "3"
+
+        # Act
+        members = list(util.get_members(TEST))
+
+        # Assert
+        assert members == [1, "two", "3"]
+
+    def test_get_members_with_prefix(self):
+        # Arrange
+        class TEST:
+            TEST_1 = 1
+            TEST_2 = "two"
+            RES_3 = "3"
+            NONE = None
+
+        # Act
+        members = list(util.get_members(TEST, prefix="TEST"))
+
+        # Assert
+        assert members == [1, "two"]
+
+    # json
+
+    def test_extract_field_from_json(self, mocker):
+        # Arrange
+        json = {"a": "1", "b": "2"}
+        get_obj_from_json = mocker.patch("hsml.util.get_obj_from_json")
+
+        # Act
+        b = util.extract_field_from_json(json, "b")
+
+        # Assert
+        assert b == "2"
+        assert get_obj_from_json.call_count == 0
+
+    def test_extract_field_from_json_fields(self, mocker):
+        # Arrange
+        json = {"a": "1", "b": "2"}
+        get_obj_from_json = mocker.patch("hsml.util.get_obj_from_json")
+
+        # Act
+        b = util.extract_field_from_json(json, ["B", "b"])  # alternative fields
+
+        # Assert
+        assert b == "2"
+        assert get_obj_from_json.call_count == 0
+
+    def test_extract_field_from_json_as_instance_of_str(self, mocker):
+        # Arrange
+        json = {"a": "1", "b": "2"}
+        get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value="2"
+        )
+
+        # Act
+        b = util.extract_field_from_json(json, "b", as_instance_of=str)
+
+        # Assert
+        assert b == "2"
+        get_obj_from_json.assert_called_once_with(obj="2", cls=str)
+
+    def test_extract_field_from_json_as_instance_of_list_str(self, mocker):
+        # Arrange
+        json = {"a": "1", "b": ["2", "2", "2"]}
+        get_obj_from_json = mocker.patch(
+            "hsml.util.get_obj_from_json", return_value="2"
+        )
+
+        # Act
+        b = util.extract_field_from_json(json, "b", as_instance_of=str)
+
+        # Assert
+        assert b == ["2", "2", "2"]
+        assert get_obj_from_json.call_count == 3
+        assert get_obj_from_json.call_args[1]["obj"] == "2"
+        assert get_obj_from_json.call_args[1]["cls"] == str
+
+    def test_get_obj_from_json_cls(self, mocker):
+        # Arrange
+        class Test:
+            def __init__(self):
+                self.a = "1"
+
+        # Act
+        obj = util.get_obj_from_json(Test(), Test)
+
+        # Assert
+        assert isinstance(obj, Test)
+        assert obj.a == "1"
+
+    def test_get_obj_from_json_dict(self, mocker):
+        # Arrange
+        class Test:
+            def __init__(self, a):
+                self.a = a
+
+            @classmethod
+            def from_json(cls, json):
+                return cls(**json)
+
+        # Act
+        obj = util.get_obj_from_json({"a": "1"}, Test)
+
+        # Assert
+        assert isinstance(obj, Test)
+        assert obj.a == "1"
+
+    def test_get_obj_from_json_dict_default(self, mocker):
+        # Arrange
+        class Test:
+            def __init__(self, a="11"):
+                self.a = "11"
+
+            @classmethod
+            def from_json(cls, json):
+                return cls(**json)
+
+        # Act
+        obj = util.get_obj_from_json({}, Test)
+
+        # Assert
+        assert isinstance(obj, Test)
+        assert obj.a == "11"
+
+    def test_get_obj_from_json_unsupported(self, mocker):
+        # Arrange
+        class Test:
+            pass
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            util.get_obj_from_json("UNSUPPORTED", Test)
+
+        # Assert
+        assert "cannot be converted to class" in str(e_info.value)

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -14,27 +14,25 @@
 #   limitations under the License.
 #
 
-import pytest
+import os
 from urllib.parse import ParseResult
 
+import pytest
 from hsml import util
 from hsml.constants import MODEL
-
 from hsml.model import Model as BaseModel
-from hsml.python.model import Model as PythonModel
-from hsml.sklearn.model import Model as SklearnModel
-from hsml.tensorflow.model import Model as TensorflowModel
-from hsml.torch.model import Model as TorchModel
-
 from hsml.predictor import Predictor as BasePredictor
-from hsml.tensorflow.predictor import Predictor as TFPredictor
-from hsml.torch.predictor import Predictor as TorchPredictor
-from hsml.sklearn.predictor import Predictor as SkLearnPredictor
+from hsml.python.model import Model as PythonModel
 from hsml.python.predictor import Predictor as PyPredictor
+from hsml.sklearn.model import Model as SklearnModel
+from hsml.sklearn.predictor import Predictor as SkLearnPredictor
+from hsml.tensorflow.model import Model as TensorflowModel
+from hsml.tensorflow.predictor import Predictor as TFPredictor
+from hsml.torch.model import Model as TorchModel
+from hsml.torch.predictor import Predictor as TorchPredictor
 
 
 class TestUtil:
-
     # schema and types
 
     # - set_model_class
@@ -239,9 +237,11 @@ class TestUtil:
     def test_compress_dir(self, mocker):
         # Arrange
         archive_name = "archive_name"
-        path_to_archive = "this/is/the/path/to/archive"
-        archive_out_path = "this/is/the/output/path/to/archive"
-        full_archive_out_path = f"{archive_out_path}/{archive_name}"
+        path_to_archive = os.path.join("this", "is", "the", "path", "to", "archive")
+        archive_out_path = os.path.join(
+            "this", "is", "the", "output", "path", "to", "archive"
+        )
+        full_archive_out_path = os.path.join(archive_out_path, archive_name)
         mock_isdir = mocker.patch("os.path.isdir", return_value=True)
         mock_shutil_make_archive = mocker.patch(
             "shutil.make_archive", return_value="resulting_path"
@@ -260,10 +260,10 @@ class TestUtil:
     def test_compress_file(self, mocker):
         # Arrange
         archive_name = "archive_name"
-        path_to_archive = "path/to/archive"
-        archive_out_path = "output/path/to/archive"
-        full_archive_out_path = f"{archive_out_path}/{archive_name}"
-        archive_path_dirname = "path/to"
+        path_to_archive = os.path.join("path", "to", "archive")
+        archive_out_path = os.path.join("output", "path", "to", "archive")
+        full_archive_out_path = os.path.join(archive_out_path, archive_name)
+        archive_path_dirname = os.path.join("path", "to")
         archive_path_basename = "archive"
         mock_isdir = mocker.patch("os.path.isdir", return_value=False)
         mock_shutil_make_archive = mocker.patch(
@@ -282,7 +282,7 @@ class TestUtil:
 
     def test_decompress(self, mocker):
         # Arrange
-        archive_file_path = "path/to/archive/file"
+        archive_file_path = os.path.join("path", "to", "archive", "file")
         extract_dir = False
         mock_shutil_unpack_archive = mocker.patch(
             "shutil.unpack_archive", return_value="resulting_path"

--- a/python/tests/utils/__init__.py
+++ b/python/tests/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2024 Logical Clocks AB
+#   Copyright 2024 Hopsworks AB
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/python/tests/utils/schema/test_column.py
+++ b/python/tests/utils/schema/test_column.py
@@ -1,0 +1,44 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from hsml.utils.schema import column
+
+
+class TestColumn:
+    def test_constructor_default(self):
+        # Arrange
+        _type = 1234
+
+        # Act
+        t = column.Column(_type)
+
+        # Assert
+        assert t.type == str(_type)
+        assert not hasattr(t, "name")
+        assert not hasattr(t, "description")
+
+    def test_constructor(self):
+        # Arrange
+        _type = 1234
+        name = 1111111
+        description = 2222222
+
+        # Act
+        t = column.Column(_type, name, description)
+
+        # Assert
+        assert t.type == str(_type)
+        assert t.name == str(name)
+        assert t.description == str(description)

--- a/python/tests/utils/schema/test_columnar_schema.py
+++ b/python/tests/utils/schema/test_columnar_schema.py
@@ -13,16 +13,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import pytest
-from mock import call
-
 import pandas as pd
-
-from hsml.utils.schema import columnar_schema, column
+import pytest
+from hsml.utils.schema import column, columnar_schema
+from mock import call
 
 
 class TestColumnarSchema:
-
     # constructor
 
     def test_constructor_default(self, mocker):
@@ -60,7 +57,7 @@ class TestColumnarSchema:
         mock_convert_pandas_series_to_schema.assert_not_called()
         mock_convert_spark_to_schema.assert_not_called()
         mock_convert_td_to_schema.assert_not_called()
-        mock_find_spec.call_count == 2
+        assert mock_find_spec.call_count == 2
 
     def test_constructor_list(self, mocker):
         # Arrange
@@ -260,7 +257,7 @@ class TestColumnarSchema:
         mock_convert_pandas_series_to_schema.assert_not_called()
         mock_convert_spark_to_schema.assert_not_called()
         mock_convert_td_to_schema.assert_called_once_with(columnar_obj)
-        mock_find_spec.call_count == 2
+        assert mock_find_spec.call_count == 2
 
     # convert list to schema
 

--- a/python/tests/utils/schema/test_columnar_schema.py
+++ b/python/tests/utils/schema/test_columnar_schema.py
@@ -1,0 +1,464 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytest
+from mock import call
+
+import pandas as pd
+
+from hsml.utils.schema import columnar_schema, column
+
+
+class TestColumnarSchema:
+
+    # constructor
+
+    def test_constructor_default(self, mocker):
+        # Arrange
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_list_to_schema",
+            return_value="convert_list_to_schema",
+        )
+        mock_convert_pandas_df_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_df_to_schema",
+            return_value="convert_pandas_df_to_schema",
+        )
+        mock_convert_pandas_series_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_series_to_schema",
+            return_value="convert_pandas_series_to_schema",
+        )
+        mock_convert_spark_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_spark_to_schema",
+            return_value="convert_spark_to_schema",
+        )
+        mock_convert_td_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_td_to_schema",
+            return_value="convert_td_to_schema",
+        )
+        mock_find_spec = mocker.patch("importlib.util.find_spec", return_value=None)
+
+        # Act
+        with pytest.raises(TypeError) as e_info:
+            _ = columnar_schema.ColumnarSchema()
+
+        # Assert
+        assert "is not supported in a columnar schema" in str(e_info.value)
+        mock_convert_list_to_schema.assert_not_called()
+        mock_convert_pandas_df_to_schema.assert_not_called()
+        mock_convert_pandas_series_to_schema.assert_not_called()
+        mock_convert_spark_to_schema.assert_not_called()
+        mock_convert_td_to_schema.assert_not_called()
+        mock_find_spec.call_count == 2
+
+    def test_constructor_list(self, mocker):
+        # Arrange
+        columnar_obj = [1, 2, 3, 4]
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_list_to_schema",
+            return_value="convert_list_to_schema",
+        )
+        mock_convert_pandas_df_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_df_to_schema",
+            return_value="convert_pandas_df_to_schema",
+        )
+        mock_convert_pandas_series_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_series_to_schema",
+            return_value="convert_pandas_series_to_schema",
+        )
+        mock_convert_spark_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_spark_to_schema",
+            return_value="convert_spark_to_schema",
+        )
+        mock_convert_td_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_td_to_schema",
+            return_value="convert_td_to_schema",
+        )
+        mock_find_spec = mocker.patch("importlib.util.find_spec", return_value=None)
+
+        # Act
+        cs = columnar_schema.ColumnarSchema(columnar_obj)
+
+        # Assert
+        assert cs.columns == "convert_list_to_schema"
+        mock_convert_list_to_schema.assert_called_once_with(columnar_obj)
+        mock_convert_pandas_df_to_schema.assert_not_called()
+        mock_convert_pandas_series_to_schema.assert_not_called()
+        mock_convert_spark_to_schema.assert_not_called()
+        mock_convert_td_to_schema.assert_not_called()
+        mock_find_spec.assert_not_called()
+
+    def test_constructor_pd_dataframe(self, mocker):
+        # Arrange
+        columnar_obj = pd.DataFrame([1, 2, 3, 4])
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_list_to_schema",
+            return_value="convert_list_to_schema",
+        )
+        mock_convert_pandas_df_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_df_to_schema",
+            return_value="convert_pandas_df_to_schema",
+        )
+        mock_convert_pandas_series_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_series_to_schema",
+            return_value="convert_pandas_series_to_schema",
+        )
+        mock_convert_spark_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_spark_to_schema",
+            return_value="convert_spark_to_schema",
+        )
+        mock_convert_td_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_td_to_schema",
+            return_value="convert_td_to_schema",
+        )
+        mock_find_spec = mocker.patch("importlib.util.find_spec", return_value=None)
+
+        # Act
+        cs = columnar_schema.ColumnarSchema(columnar_obj)
+
+        # Assert
+        assert cs.columns == "convert_pandas_df_to_schema"
+        mock_convert_list_to_schema.assert_not_called()
+        mock_convert_pandas_df_to_schema.assert_called_once_with(columnar_obj)
+        mock_convert_pandas_series_to_schema.assert_not_called()
+        mock_convert_spark_to_schema.assert_not_called()
+        mock_convert_td_to_schema.assert_not_called()
+        mock_find_spec.assert_not_called()
+
+    def test_constructor_pd_series(self, mocker):
+        # Arrange
+        columnar_obj = pd.Series([1, 2, 3, 4])
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_list_to_schema",
+            return_value="convert_list_to_schema",
+        )
+        mock_convert_pandas_df_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_df_to_schema",
+            return_value="convert_pandas_df_to_schema",
+        )
+        mock_convert_pandas_series_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_series_to_schema",
+            return_value="convert_pandas_series_to_schema",
+        )
+        mock_convert_spark_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_spark_to_schema",
+            return_value="convert_spark_to_schema",
+        )
+        mock_convert_td_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_td_to_schema",
+            return_value="convert_td_to_schema",
+        )
+        mock_find_spec = mocker.patch("importlib.util.find_spec", return_value=None)
+
+        # Act
+        cs = columnar_schema.ColumnarSchema(columnar_obj)
+
+        # Assert
+        assert cs.columns == "convert_pandas_series_to_schema"
+        mock_convert_list_to_schema.assert_not_called()
+        mock_convert_pandas_df_to_schema.assert_not_called()
+        mock_convert_pandas_series_to_schema.assert_called_once_with(columnar_obj)
+        mock_convert_spark_to_schema.assert_not_called()
+        mock_convert_td_to_schema.assert_not_called()
+        mock_find_spec.assert_not_called()
+
+    def test_constructor_pyspark_dataframe(self, mocker):
+        try:
+            import pyspark
+        except ImportError:
+            pytest.skip("pyspark not available")
+
+        # Arrange
+        columnar_obj = mocker.MagicMock(spec=pyspark.sql.dataframe.DataFrame)
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_list_to_schema",
+            return_value="convert_list_to_schema",
+        )
+        mock_convert_pandas_df_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_df_to_schema",
+            return_value="convert_pandas_df_to_schema",
+        )
+        mock_convert_pandas_series_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_series_to_schema",
+            return_value="convert_pandas_series_to_schema",
+        )
+        mock_convert_spark_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_spark_to_schema",
+            return_value="convert_spark_to_schema",
+        )
+        mock_convert_td_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_td_to_schema",
+            return_value="convert_td_to_schema",
+        )
+        mock_find_spec = mocker.patch(
+            "importlib.util.find_spec", return_value="Not None"
+        )
+
+        # Act
+        cs = columnar_schema.ColumnarSchema(columnar_obj)
+
+        # Assert
+        assert cs.columns == "convert_spark_to_schema"
+        mock_convert_list_to_schema.assert_not_called()
+        mock_convert_pandas_df_to_schema.assert_not_called()
+        mock_convert_pandas_series_to_schema.assert_not_called()
+        mock_convert_spark_to_schema.assert_called_once_with(columnar_obj)
+        mock_convert_td_to_schema.assert_not_called()
+        mock_find_spec.assert_called_once_with("pyspark")
+
+    def test_constructor_hsfs_td(self, mocker):
+        # Arrange
+        try:
+            import hsfs
+        except ImportError:
+            pytest.skip("hsfs not available")
+
+        # Arrange
+        columnar_obj = mocker.MagicMock(spec=hsfs.training_dataset.TrainingDataset)
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_list_to_schema",
+            return_value="convert_list_to_schema",
+        )
+        mock_convert_pandas_df_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_df_to_schema",
+            return_value="convert_pandas_df_to_schema",
+        )
+        mock_convert_pandas_series_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_pandas_series_to_schema",
+            return_value="convert_pandas_series_to_schema",
+        )
+        mock_convert_spark_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_spark_to_schema",
+            return_value="convert_spark_to_schema",
+        )
+        mock_convert_td_to_schema = mocker.patch(
+            "hsml.utils.schema.columnar_schema.ColumnarSchema._convert_td_to_schema",
+            return_value="convert_td_to_schema",
+        )
+        mock_find_spec = mocker.patch(
+            "importlib.util.find_spec", return_value="Not None"
+        )
+
+        # Act
+        cs = columnar_schema.ColumnarSchema(columnar_obj)
+
+        # Assert
+        assert cs.columns == "convert_td_to_schema"
+        mock_convert_list_to_schema.assert_not_called()
+        mock_convert_pandas_df_to_schema.assert_not_called()
+        mock_convert_pandas_series_to_schema.assert_not_called()
+        mock_convert_spark_to_schema.assert_not_called()
+        mock_convert_td_to_schema.assert_called_once_with(columnar_obj)
+        mock_find_spec.call_count == 2
+
+    # convert list to schema
+
+    def test_convert_list_to_schema(self, mocker):
+        # Arrange
+        columnar_obj = [1, 2, 3, 4]
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._convert_list_to_schema = (
+            columnar_schema.ColumnarSchema._convert_list_to_schema
+        )
+        mock_columnar_schema._build_column.side_effect = columnar_obj
+
+        # Act
+        c = mock_columnar_schema._convert_list_to_schema(
+            mock_columnar_schema, columnar_obj
+        )
+
+        # Assert
+        expected_calls = [call(cv) for cv in columnar_obj]
+        mock_columnar_schema._build_column.assert_has_calls(expected_calls)
+        assert mock_columnar_schema._build_column.call_count == len(columnar_obj)
+        assert c == columnar_obj
+
+    # convert pandas df to schema
+
+    def test_convert_pd_dataframe_to_schema(self, mocker):
+        # Arrange
+        columnar_obj = pd.DataFrame([[1, 2], [3, 4], [1, 2], [3, 4]])
+        mock_column_init = mocker.patch(
+            "hsml.utils.schema.column.Column.__init__", return_value=None
+        )
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._convert_pandas_df_to_schema = (
+            columnar_schema.ColumnarSchema._convert_pandas_df_to_schema
+        )
+
+        # Act
+        c = mock_columnar_schema._convert_pandas_df_to_schema(
+            mock_columnar_schema, columnar_obj
+        )
+
+        # Assert
+        cols = columnar_obj.columns
+        dtypes = columnar_obj.dtypes
+        expected_calls = [call(dtypes[col], name=col) for col in cols]
+        mock_column_init.assert_has_calls(expected_calls)
+        assert mock_column_init.call_count == 2
+        assert len(c) == 2
+
+    # convert pandas series to schema
+
+    def test_convert_pd_series_to_schema(self, mocker):
+        # Arrange
+        columnar_obj = pd.Series([1, 2, 3, 4])
+        mock_column_init = mocker.patch(
+            "hsml.utils.schema.column.Column.__init__", return_value=None
+        )
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._convert_pandas_series_to_schema = (
+            columnar_schema.ColumnarSchema._convert_pandas_series_to_schema
+        )
+
+        # Act
+        c = mock_columnar_schema._convert_pandas_series_to_schema(
+            mock_columnar_schema, columnar_obj
+        )
+
+        # Assert
+        expected_call = call(columnar_obj.dtype, name=columnar_obj.name)
+        mock_column_init.assert_has_calls([expected_call])
+        assert mock_column_init.call_count == 1
+        assert len(c) == 1
+
+    # convert spark to schema
+
+    def test_convert_spark_to_schema(self, mocker):
+        # Arrange
+        try:
+            import pyspark
+        except ImportError:
+            pytest.skip("pyspark not available")
+
+        # Arrange
+        columnar_obj = mocker.MagicMock(spec=pyspark.sql.dataframe.DataFrame)
+        columnar_obj.dtypes = [("name_1", "type_1"), ("name_2", "type_2")]
+        mock_column_init = mocker.patch(
+            "hsml.utils.schema.column.Column.__init__", return_value=None
+        )
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._convert_spark_to_schema = (
+            columnar_schema.ColumnarSchema._convert_spark_to_schema
+        )
+
+        # Act
+        c = mock_columnar_schema._convert_spark_to_schema(
+            mock_columnar_schema, columnar_obj
+        )
+
+        # Assert
+        expected_calls = [call(dtype, name=name) for name, dtype in columnar_obj.dtypes]
+        mock_column_init.assert_has_calls(expected_calls)
+        assert mock_column_init.call_count == len(columnar_obj.dtypes)
+        assert len(c) == len(columnar_obj.dtypes)
+
+    # convert td to schema
+
+    def test_convert_td_to_schema(self, mocker):
+        # Arrange
+        class MockFeature:
+            def __init__(self, fname, ftype):
+                self.name = fname
+                self.type = ftype
+
+        columnar_obj = mocker.MagicMock()
+        columnar_obj.schema = [
+            MockFeature("name_1", "type_1"),
+            MockFeature("name_2", "type_2"),
+        ]
+        mock_column_init = mocker.patch(
+            "hsml.utils.schema.column.Column.__init__", return_value=None
+        )
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._convert_td_to_schema = (
+            columnar_schema.ColumnarSchema._convert_td_to_schema
+        )
+
+        # Act
+        c = mock_columnar_schema._convert_td_to_schema(
+            mock_columnar_schema, columnar_obj
+        )
+
+        # Assert
+        expected_calls = [
+            call(feat.type, name=feat.name) for feat in columnar_obj.schema
+        ]
+        mock_column_init.assert_has_calls(expected_calls)
+        assert mock_column_init.call_count == len(columnar_obj.schema)
+        assert len(c) == len(columnar_obj.schema)
+
+    # build column
+
+    def test_build_column_type_only(self, mocker):
+        # Arrange
+        columnar_obj = {"type": "tensor_type"}
+        mock_column_init = mocker.patch(
+            "hsml.utils.schema.column.Column.__init__", return_value=None
+        )
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._build_column = (
+            columnar_schema.ColumnarSchema._build_column
+        )
+
+        # Act
+        c = mock_columnar_schema._build_column(mock_columnar_schema, columnar_obj)
+
+        # Assert
+        assert isinstance(c, column.Column)
+        mock_column_init.assert_called_once_with(
+            columnar_obj["type"], name=None, description=None
+        )
+
+    def test_build_tensor_invalid_missing_type(self, mocker):
+        # Arrange
+        columnar_obj = {}
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._build_column = (
+            columnar_schema.ColumnarSchema._build_column
+        )
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = mock_columnar_schema._build_column(mock_columnar_schema, columnar_obj)
+
+        # Assert
+        assert "Mandatory 'type' key missing from entry" in str(e_info.value)
+
+    def test_build_tensor_type_name_and_description(self, mocker):
+        # Arrange
+        columnar_obj = {
+            "type": "tensor_type",
+            "name": "tensor_name",
+            "description": "tensor_description",
+        }
+        mock_column_init = mocker.patch(
+            "hsml.utils.schema.column.Column.__init__", return_value=None
+        )
+        mock_columnar_schema = mocker.MagicMock()
+        mock_columnar_schema._build_column = (
+            columnar_schema.ColumnarSchema._build_column
+        )
+
+        # Act
+        c = mock_columnar_schema._build_column(mock_columnar_schema, columnar_obj)
+
+        # Assert
+        assert isinstance(c, column.Column)
+        mock_column_init.assert_called_once_with(
+            columnar_obj["type"],
+            name=columnar_obj["name"],
+            description=columnar_obj["description"],
+        )

--- a/python/tests/utils/schema/test_tensor.py
+++ b/python/tests/utils/schema/test_tensor.py
@@ -1,0 +1,48 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from hsml.utils.schema import tensor
+
+
+class TestTensor:
+    def test_constructor_default(self):
+        # Arrange
+        _type = 1234
+        shape = 4321
+
+        # Act
+        t = tensor.Tensor(_type, shape)
+
+        # Assert
+        assert t.type == str(_type)
+        assert t.shape == str(shape)
+        assert not hasattr(t, "name")
+        assert not hasattr(t, "description")
+
+    def test_constructor(self):
+        # Arrange
+        _type = 1234
+        shape = 4321
+        name = 1111111
+        description = 2222222
+
+        # Act
+        t = tensor.Tensor(_type, shape, name, description)
+
+        # Assert
+        assert t.type == str(_type)
+        assert t.shape == str(shape)
+        assert t.name == str(name)
+        assert t.description == str(description)

--- a/python/tests/utils/schema/test_tensor_schema.py
+++ b/python/tests/utils/schema/test_tensor_schema.py
@@ -13,14 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import pytest
 import numpy as np
-
-from hsml.utils.schema import tensor_schema, tensor
+import pytest
+from hsml.utils.schema import tensor, tensor_schema
 
 
 class TestTensorSchema:
-
     # constructor
 
     def test_constructor_default(self):
@@ -131,7 +129,7 @@ class TestTensorSchema:
         # Assert
         assert isinstance(t, list)
         assert len(t) == len(tensor_obj)
-        mock_tensor_schema._build_tensor.call_count == len(tensor_obj)
+        assert mock_tensor_schema._build_tensor.call_count == len(tensor_obj)
 
     # build tensor
 

--- a/python/tests/utils/schema/test_tensor_schema.py
+++ b/python/tests/utils/schema/test_tensor_schema.py
@@ -1,0 +1,206 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytest
+import numpy as np
+
+from hsml.utils.schema import tensor_schema, tensor
+
+
+class TestTensorSchema:
+
+    # constructor
+
+    def test_constructor_default(self):
+        # Act
+        with pytest.raises(TypeError) as e_info:
+            _ = tensor_schema.TensorSchema()
+
+        # Assert
+        assert "is not supported in a tensor schema" in str(e_info.value)
+
+    def test_constructor_invalid(self):
+        # Act
+        with pytest.raises(TypeError) as e_info:
+            _ = tensor_schema.TensorSchema("invalid")
+
+        # Assert
+        assert "is not supported in a tensor schema" in str(e_info.value)
+
+    def test_constructor_list(self, mocker):
+        # Arrange
+        tensor_obj = [1234, 4321, 1111111, 2222222]
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.tensor_schema.TensorSchema._convert_list_to_schema",
+            return_value="list_to_schema",
+        )
+        mock_convert_tensor_to_schema = mocker.patch(
+            "hsml.utils.schema.tensor_schema.TensorSchema._convert_tensor_to_schema",
+            return_value="tensor_to_schema",
+        )
+
+        # Act
+        ts = tensor_schema.TensorSchema(tensor_obj)
+
+        # Assert
+        assert ts.tensors == "list_to_schema"
+        mock_convert_list_to_schema.assert_called_once_with(tensor_obj)
+        mock_convert_tensor_to_schema.assert_not_called()
+
+    def test_constructor_ndarray(self, mocker):
+        # Arrange
+        tensor_obj = np.array([1234, 4321, 1111111, 2222222])
+        mock_convert_list_to_schema = mocker.patch(
+            "hsml.utils.schema.tensor_schema.TensorSchema._convert_list_to_schema",
+            return_value="list_to_schema",
+        )
+        mock_convert_tensor_to_schema = mocker.patch(
+            "hsml.utils.schema.tensor_schema.TensorSchema._convert_tensor_to_schema",
+            return_value="tensor_to_schema",
+        )
+
+        # Act
+        ts = tensor_schema.TensorSchema(tensor_obj)
+
+        # Assert
+        assert ts.tensors == "tensor_to_schema"
+        mock_convert_tensor_to_schema.assert_called_once_with(tensor_obj)
+        mock_convert_list_to_schema.assert_not_called()
+
+    # convert tensor to schema
+
+    def test_convert_tensor_to_schema(self, mocker):
+        # Arrange
+        tensor_obj = mocker.MagicMock()
+        mock_tensor_schema = mocker.MagicMock()
+        mock_tensor_schema._convert_tensor_to_schema = (
+            tensor_schema.TensorSchema._convert_tensor_to_schema
+        )
+        mock_tensor_init = mocker.patch(
+            "hsml.utils.schema.tensor.Tensor.__init__", return_value=None
+        )
+
+        # Act
+        t = mock_tensor_schema._convert_tensor_to_schema(mock_tensor_schema, tensor_obj)
+
+        # Assert
+        assert isinstance(t, tensor.Tensor)
+        mock_tensor_init.assert_called_once_with(tensor_obj.dtype, tensor_obj.shape)
+
+    # convert list to schema
+
+    def test_convert_list_to_schema_singleton(self, mocker):
+        # Arrange
+        tensor_obj = [1234]
+        mock_tensor_schema = mocker.MagicMock()
+        mock_tensor_schema._convert_list_to_schema = (
+            tensor_schema.TensorSchema._convert_list_to_schema
+        )
+
+        # Act
+        t = mock_tensor_schema._convert_list_to_schema(mock_tensor_schema, tensor_obj)
+
+        # Assert
+        assert isinstance(t, list)
+        assert len(t) == len(tensor_obj)
+        mock_tensor_schema._build_tensor.assert_called_once_with(1234)
+
+    def test_convert_list_to_schema_list(self, mocker):
+        # Arrange
+        tensor_obj = np.array([1234, 4321, 1111111, 2222222])
+        mock_tensor_schema = mocker.MagicMock()
+        mock_tensor_schema._convert_list_to_schema = (
+            tensor_schema.TensorSchema._convert_list_to_schema
+        )
+
+        # Act
+        t = mock_tensor_schema._convert_list_to_schema(mock_tensor_schema, tensor_obj)
+
+        # Assert
+        assert isinstance(t, list)
+        assert len(t) == len(tensor_obj)
+        mock_tensor_schema._build_tensor.call_count == len(tensor_obj)
+
+    # build tensor
+
+    def test_build_tensor_type_and_shape_only(self, mocker):
+        # Arrange
+        tensor_obj = {"type": "tensor_type", "shape": "tensor_shape"}
+        mock_tensor_init = mocker.patch(
+            "hsml.utils.schema.tensor.Tensor.__init__", return_value=None
+        )
+        mock_tensor_schema = mocker.MagicMock()
+        mock_tensor_schema._build_tensor = tensor_schema.TensorSchema._build_tensor
+
+        # Act
+        t = mock_tensor_schema._build_tensor(mock_tensor_schema, tensor_obj)
+
+        # Assert
+        assert isinstance(t, tensor.Tensor)
+        mock_tensor_init.assert_called_once_with(
+            tensor_obj["type"], tensor_obj["shape"], name=None, description=None
+        )
+
+    def test_build_tensor_invalid_missing_type(self, mocker):
+        # Arrange
+        tensor_obj = {"shape": "tensor_shape"}
+        mock_tensor_schema = mocker.MagicMock()
+        mock_tensor_schema._build_tensor = tensor_schema.TensorSchema._build_tensor
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = mock_tensor_schema._build_tensor(mock_tensor_schema, tensor_obj)
+
+        # Assert
+        assert "Mandatory 'type' key missing from entry" in str(e_info.value)
+
+    def test_build_tensor_invalid_missing_shape(self, mocker):
+        # Arrange
+        tensor_obj = {"type": "tensor_type"}
+        mock_tensor_schema = mocker.MagicMock()
+        mock_tensor_schema._build_tensor = tensor_schema.TensorSchema._build_tensor
+
+        # Act
+        with pytest.raises(ValueError) as e_info:
+            _ = mock_tensor_schema._build_tensor(mock_tensor_schema, tensor_obj)
+
+        # Assert
+        assert "Mandatory 'shape' key missing from entry" in str(e_info.value)
+
+    def test_build_tensor_type_shape_name_and_description(self, mocker):
+        # Arrange
+        tensor_obj = {
+            "type": "tensor_type",
+            "shape": "tensor_shape",
+            "name": "tensor_name",
+            "description": "tensor_description",
+        }
+        mock_tensor_init = mocker.patch(
+            "hsml.utils.schema.tensor.Tensor.__init__", return_value=None
+        )
+        mock_tensor_schema = mocker.MagicMock()
+        mock_tensor_schema._build_tensor = tensor_schema.TensorSchema._build_tensor
+
+        # Act
+        t = mock_tensor_schema._build_tensor(mock_tensor_schema, tensor_obj)
+
+        # Assert
+        assert isinstance(t, tensor.Tensor)
+        mock_tensor_init.assert_called_once_with(
+            tensor_obj["type"],
+            tensor_obj["shape"],
+            name=tensor_obj["name"],
+            description=tensor_obj["description"],
+        )


### PR DESCRIPTION
This PR includes ~340 pytests for the POJO classes and constants (located in the hsml directory). Pytests for anything under `engine `or `core` directories are excluded in this PR.