### PR TITLE
[HWORKS-108] Allow users to stop deployments at any time

### DIFF
--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -222,16 +222,6 @@ class ServingEngine:
             if state.status == PREDICTOR_STATE.STATUS_STOPPING:
                 print("Deployment is already stopping")
                 return (True, state)
-            if state.status == PREDICTOR_STATE.STATUS_STARTING:
-                if state.condition is not None:
-                    raise ModelServingException(
-                        "Deployment is starting, please wait until it completely starts"
-                    )
-            if state.status == PREDICTOR_STATE.STATUS_UPDATING:
-                if state.condition is not None:
-                    raise ModelServingException(
-                        "Deployment is updating, please wait until the update completes"
-                    )
 
         return (False, state)
 


### PR DESCRIPTION
**A user tries to stop a deployment that was started less than 30 seconds ago.**

<img width="1404" alt="image" src="https://github.com/logicalclocks/machine-learning-api/assets/8671191/2ba4eade-a060-4e8a-b588-a9c34b6d9ee3">
